### PR TITLE
Adopt hosted comparevi-history diagnostics facade

### DIFF
--- a/.github/workflows/comparevi-history-comment-gated.yml
+++ b/.github/workflows/comparevi-history-comment-gated.yml
@@ -1,0 +1,177 @@
+name: CompareVI History Comment-Gated Diagnostics
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: comparevi-history-${{ github.repository }}-hosted-linux
+  cancel-in-progress: false
+
+jobs:
+  comparevi-history-comment:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/comparevi-history') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      DEFAULT_COMPARE_MODES: default,attributes,front-panel,block-diagram
+      DEFAULT_MAX_PAIRS: "5"
+      DEFAULT_MAX_SIGNAL_PAIRS: "5"
+      FACADE_REF: v1.0.3
+      COMPAREVI_NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
+    steps:
+      - name: Validate maintainer command and resolve PR head
+        id: request
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $allowedAssociations = @('OWNER', 'MEMBER', 'COLLABORATOR')
+          if ($env:AUTHOR_ASSOCIATION -notin $allowedAssociations) {
+            throw "Only trusted maintainers may invoke /comparevi-history. Current author_association is '$($env:AUTHOR_ASSOCIATION)'."
+          }
+
+          $command = $env:COMMENT_BODY.Trim()
+          $prefix = '/comparevi-history'
+          if (-not $command.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw 'Unsupported command.'
+          }
+
+          $remainder = $command.Substring($prefix.Length).Trim()
+          if ([string]::IsNullOrWhiteSpace($remainder)) {
+            throw 'Usage: /comparevi-history <repository-relative-vi-path> [--modes comma,list]'
+          }
+
+          $targetPath = $remainder
+          $compareModes = $env:DEFAULT_COMPARE_MODES
+          $modeMarker = ' --modes '
+          $modeIndex = $remainder.IndexOf($modeMarker, [System.StringComparison]::OrdinalIgnoreCase)
+          if ($modeIndex -ge 0) {
+            $targetPath = $remainder.Substring(0, $modeIndex).Trim()
+            $compareModes = $remainder.Substring($modeIndex + $modeMarker.Length).Trim()
+          }
+
+          if ([string]::IsNullOrWhiteSpace($targetPath)) {
+            throw 'The slash command must include a repository-relative VI path.'
+          }
+          if ([string]::IsNullOrWhiteSpace($compareModes)) {
+            $compareModes = $env:DEFAULT_COMPARE_MODES
+          }
+
+          $headers = @{
+            Accept = 'application/vnd.github+json'
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            'User-Agent' = 'labview-icon-editor-demo-comparevi-history'
+            'X-GitHub-Api-Version' = '2022-11-28'
+          }
+
+          $uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/pulls/$env:ISSUE_NUMBER"
+          $pr = Invoke-RestMethod -Uri $uri -Headers $headers
+          if ($pr.state -ne 'open') {
+            throw "Pull request #$($env:ISSUE_NUMBER) is not open."
+          }
+
+          @(
+            "target-path=$targetPath"
+            "compare-modes=$compareModes"
+            "head-repo=$($pr.head.repo.full_name)"
+            "head-sha=$($pr.head.sha)"
+            "head-ref=$($pr.head.ref)"
+            "is-fork=$([bool]$pr.head.repo.fork)"
+          ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Pre-pull NI Linux image
+        shell: bash
+        run: docker pull "$COMPAREVI_NI_LINUX_IMAGE"
+
+      - name: Checkout PR head repository
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ steps.request.outputs['head-repo'] }}
+          ref: ${{ steps.request.outputs['head-sha'] }}
+          fetch-depth: 0
+
+      - name: Run comparevi-history
+        id: history
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.0.3
+        with:
+          target_path: ${{ steps.request.outputs['target-path'] }}
+          start_ref: ${{ steps.request.outputs['head-sha'] }}
+          mode: ${{ steps.request.outputs['compare-modes'] }}
+          max_pairs: ${{ env.DEFAULT_MAX_PAIRS }}
+          max_signal_pairs: ${{ env.DEFAULT_MAX_SIGNAL_PAIRS }}
+          render_report: true
+          detailed: true
+          fail_on_diff: false
+          results_dir: tests/results/pr-diagnostics/history
+          invoke_script_path: Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1
+
+      - name: Upload diagnostics artifacts
+        if: ${{ always() && steps.history.outputs['results-dir'] != '' }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: comparevi-history-pr-${{ github.event.issue.number }}
+          path: ${{ steps.history.outputs['results-dir'] }}/**
+          if-no-files-found: error
+
+      - name: Post PR comment
+        if: ${{ always() }}
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.0.3
+          TARGET_PATH: ${{ steps.request.outputs['target-path'] }}
+          REQUESTED_MODES: ${{ steps.history.outputs['requested-mode-list'] }}
+          EXECUTED_MODES: ${{ steps.history.outputs['executed-mode-list'] }}
+          TOTAL_PROCESSED: ${{ steps.history.outputs['total-processed'] }}
+          TOTAL_DIFFS: ${{ steps.history.outputs['total-diffs'] }}
+          MODE_SUMMARY_MARKDOWN: ${{ steps.history.outputs['mode-summary-markdown'] }}
+          STEP_CONCLUSION: ${{ steps.history.conclusion }}
+          IS_FORK: ${{ steps.request.outputs['is-fork'] }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $headers = @{
+            Accept = 'application/vnd.github+json'
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            'User-Agent' = 'labview-icon-editor-demo-comparevi-history'
+            'X-GitHub-Api-Version' = '2022-11-28'
+          }
+
+          $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          $body = @"
+          comparevi-history diagnostics finished for PR #$env:ISSUE_NUMBER.
+
+          - Action ref: `$env:ACTION_REF`
+          - Target path: `$env:TARGET_PATH`
+          - Container image: `$env:COMPAREVI_NI_LINUX_IMAGE`
+          - Requested modes: `$env:REQUESTED_MODES`
+          - Executed modes: `$env:EXECUTED_MODES`
+          - Total processed: `$env:TOTAL_PROCESSED`
+          - Total diffs: `$env:TOTAL_DIFFS`
+          - Step conclusion: `$env:STEP_CONCLUSION`
+          - PR head is fork: `$env:IS_FORK`
+
+          ### Mode coverage
+          $env:MODE_SUMMARY_MARKDOWN
+
+          - Run: $runUrl
+          "@.Trim()
+
+          $payload = @{ body = $body } | ConvertTo-Json -Depth 5
+          $uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/issues/$env:ISSUE_NUMBER/comments"
+          Invoke-RestMethod -Method Post -Uri $uri -Headers $headers -Body $payload -ContentType 'application/json'

--- a/.github/workflows/comparevi-history-manual-pr-diagnostics.yml
+++ b/.github/workflows/comparevi-history-manual-pr-diagnostics.yml
@@ -1,0 +1,146 @@
+name: CompareVI History Manual PR Diagnostics
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request number to inspect
+        required: true
+        type: string
+      target_path:
+        description: Repository-relative VI path to inspect
+        required: true
+        type: string
+      compare_modes:
+        description: Comma-separated compare mode bundle
+        required: false
+        default: default,attributes,front-panel,block-diagram
+        type: string
+      max_pairs:
+        description: Maximum adjacent commit pairs to process
+        required: false
+        default: "5"
+        type: string
+      max_signal_pairs:
+        description: Maximum surfaced signal pairs
+        required: false
+        default: "5"
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: comparevi-history-${{ github.repository }}-hosted-linux
+  cancel-in-progress: false
+
+jobs:
+  comparevi-history-manual:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      COMPAREVI_NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
+    steps:
+      - name: Resolve pull request head
+        id: pr
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $headers = @{
+            Accept = 'application/vnd.github+json'
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            'User-Agent' = 'labview-icon-editor-demo-comparevi-history'
+            'X-GitHub-Api-Version' = '2022-11-28'
+          }
+
+          $uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/pulls/$env:PULL_REQUEST_NUMBER"
+          $pr = Invoke-RestMethod -Uri $uri -Headers $headers
+          if ($pr.state -ne 'open') {
+            throw "Pull request #$($env:PULL_REQUEST_NUMBER) is not open."
+          }
+
+          @(
+            "head-repo=$($pr.head.repo.full_name)"
+            "head-sha=$($pr.head.sha)"
+            "head-ref=$($pr.head.ref)"
+            "is-fork=$([bool]$pr.head.repo.fork)"
+          ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Pre-pull NI Linux image
+        shell: bash
+        run: docker pull "$COMPAREVI_NI_LINUX_IMAGE"
+
+      - name: Checkout PR head repository
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ steps.pr.outputs['head-repo'] }}
+          ref: ${{ steps.pr.outputs['head-sha'] }}
+          fetch-depth: 0
+
+      - name: Run comparevi-history
+        id: history
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1
+        with:
+          target_path: ${{ inputs.target_path }}
+          start_ref: ${{ steps.pr.outputs['head-sha'] }}
+          mode: ${{ inputs.compare_modes }}
+          max_pairs: ${{ inputs.max_pairs }}
+          max_signal_pairs: ${{ inputs.max_signal_pairs }}
+          render_report: true
+          detailed: true
+          fail_on_diff: false
+          results_dir: tests/results/pr-diagnostics/history
+          invoke_script_path: Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1
+
+      - name: Upload diagnostics artifacts
+        if: ${{ always() && steps.history.outputs['results-dir'] != '' }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: comparevi-history-pr-${{ inputs.pull_request_number }}
+          path: ${{ steps.history.outputs['results-dir'] }}/**
+          if-no-files-found: error
+
+      - name: Summarize diagnostics
+        if: ${{ always() }}
+        shell: pwsh
+        env:
+          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1
+          PR_NUMBER: ${{ inputs.pull_request_number }}
+          TARGET_PATH: ${{ inputs.target_path }}
+          REQUESTED_MODES: ${{ steps.history.outputs['requested-mode-list'] }}
+          EXECUTED_MODES: ${{ steps.history.outputs['executed-mode-list'] }}
+          TOTAL_PROCESSED: ${{ steps.history.outputs['total-processed'] }}
+          TOTAL_DIFFS: ${{ steps.history.outputs['total-diffs'] }}
+          RESULTS_DIR: ${{ steps.history.outputs['results-dir'] }}
+          MODE_SUMMARY_MARKDOWN: ${{ steps.history.outputs['mode-summary-markdown'] }}
+          IS_FORK: ${{ steps.pr.outputs['is-fork'] }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          @(
+            '## comparevi-history manual PR diagnostics'
+            ''
+            ('- Action ref: `{0}`' -f $env:ACTION_REF)
+            ('- Pull request: `#{0}`' -f $env:PR_NUMBER)
+            ('- Target path: `{0}`' -f $env:TARGET_PATH)
+            ('- Container image: `{0}`' -f $env:COMPAREVI_NI_LINUX_IMAGE)
+            ('- Requested modes: `{0}`' -f $env:REQUESTED_MODES)
+            ('- Executed modes: `{0}`' -f $env:EXECUTED_MODES)
+            ('- Total processed: `{0}`' -f $env:TOTAL_PROCESSED)
+            ('- Total diffs: `{0}`' -f $env:TOTAL_DIFFS)
+            ('- Results dir: `{0}`' -f $env:RESULTS_DIR)
+            ('- PR head is fork: `{0}`' -f $env:IS_FORK)
+            ('- Run URL: {0}' -f $runUrl)
+            ''
+            '### Mode coverage'
+            ''
+            $env:MODE_SUMMARY_MARKDOWN
+          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ For additional details and troubleshooting tips, see [INSTALL.md](INSTALL.md).
 3. **CI/CD Workflows** – GitHub Actions workflows are provided for common tasks:
    - **Build VI Package** – Compiles the source and produces a `.vip` artifact (VI Package).
    - **Run Unit Tests** (now part of the main CI pipeline) – Executes automated tests to verify the Icon Editor’s behavior in a clean LabVIEW environment.
+   - **CompareVI History Diagnostics** – Maintainer-triggered workflows can inspect released `comparevi-history`
+     diagnostics for pull requests without exposing the facade to untrusted PR events.
    Additional details on these pipelines are in [CI Workflows](docs/ci-workflows.md) and the [CI Workflow (Multi-Channel Release Support)](docs/powershell-cli-github-action-instructions.md).
 
 ---
@@ -112,6 +114,8 @@ For very large or long-term contributions, NI may use an `experiment/<feature-na
 In-depth documentation and reference guides are located in the `/docs` directory. A complete index is available in [docs/README.md](docs/README.md). Notable documents include:
 
 - **Build & CI Guides:** How to build the Icon Editor and use continuous integration tools. For local setup, see [manual-instructions.md](docs/manual-instructions.md) or the script-driven [automated-setup.md](docs/automated-setup.md). CI pipelines are covered in [CI Workflows](docs/ci-workflows.md) and the [CI Workflow (Multi-Channel Release Support)](docs/powershell-cli-github-action-instructions.md). Reference scripts are listed in [PowerShell Dependency Scripts](docs/powershell-dependency-scripts.md). Packaging and runner configuration are detailed in [Build VI Package](docs/ci/actions/build-vi-package.md) and the [Runner Setup Guide](docs/ci/actions/runner-setup-guide.md).
+- **PR Diagnostics:** Released-ref PR diagnostics guidance for maintainers and downstream forks is documented in
+  [CompareVI History Diagnostics](docs/comparevi-history-diagnostics.md).
 - **Composite Actions:** Summary of the repository's reusable GitHub Actions is available in [Composite Actions](docs/ci/actions/README.md).
 - **Advanced Workflows:** Details on complex release processes and branching strategies. For example, the [Multichannel Release Workflow](docs/ci/actions/multichannel-release-workflow.md) explains alpha/beta/RC release branches, and [EXPERIMENTS.md](docs/ci/experiments.md) covers long-running feature branches. Maintainers can refer to the [Maintainer's Guide](docs/ci/actions/maintainers-guide.md) for internal release duties.
 - **Troubleshooting:** If you encounter issues, see the [Troubleshooting & FAQ](docs/ci/troubleshooting-faq.md) for common problems (environment setup, build failures, etc.). There is also a specialized [Experiments Troubleshooting](docs/ci/actions/troubleshooting-experiments.md) guide for experimental branch issues.

--- a/Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1
+++ b/Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1
@@ -1,0 +1,285 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string]$BaseVi,
+    [string]$HeadVi,
+    [string]$OutputDir,
+    [string]$LabVIEWExePath,
+    [string]$LabVIEWBitness = '64',
+    [string]$LVComparePath,
+    [string[]]$Flags,
+    [switch]$ReplaceFlags,
+    [switch]$AllowSameLeaf,
+    [switch]$RenderReport,
+    [ValidateSet('html', 'xml', 'text')]
+    [string[]]$ReportFormat = @('html'),
+    [string]$JsonLogPath,
+    [switch]$Quiet,
+    [switch]$LeakCheck,
+    [double]$LeakGraceSeconds = 0,
+    [string]$LeakJsonPath,
+    [string]$CaptureScriptPath,
+    [switch]$Summary,
+    [Nullable[int]]$TimeoutSeconds,
+    [string]$NoiseProfile = 'full',
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$PassThru
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Resolve-AbsolutePath {
+    param(
+        [Parameter(Mandatory = $true)][string]$PathValue,
+        [Parameter(Mandatory = $true)][string]$BasePath
+    )
+
+    if ([System.IO.Path]::IsPathRooted($PathValue)) {
+        return [System.IO.Path]::GetFullPath($PathValue)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $BasePath $PathValue))
+}
+
+function Resolve-OutputDirectory {
+    param([AllowNull()][string]$PathValue)
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        $tempRoot = [System.IO.Path]::GetTempPath()
+        return Join-Path $tempRoot ("comparevi-history-linux-" + [guid]::NewGuid().ToString('N'))
+    }
+
+    return Resolve-AbsolutePath -PathValue $PathValue -BasePath (Get-Location).Path
+}
+
+function Resolve-HostedCompareReportType {
+    param(
+        [string[]]$ReportFormatValue,
+        [switch]$RenderReportValue
+    )
+
+    foreach ($candidate in @($ReportFormatValue)) {
+        if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+            return $candidate.Trim().ToLowerInvariant()
+        }
+    }
+
+    $envValue = [System.Environment]::GetEnvironmentVariable('COMPAREVI_REPORT_FORMAT', 'Process')
+    if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+        return $envValue.Trim().ToLowerInvariant()
+    }
+
+    if ($RenderReportValue.IsPresent) {
+        return 'html'
+    }
+
+    return 'html'
+}
+
+function Resolve-HostedCompareFlags {
+    param(
+        [string[]]$FlagValues,
+        [switch]$ReplaceFlagsValue
+    )
+
+    $resolved = New-Object System.Collections.Generic.List[string]
+    if (-not $ReplaceFlagsValue.IsPresent) {
+        $envFlags = [System.Environment]::GetEnvironmentVariable('COMPAREVI_LVCOMPARE_FLAGS', 'Process')
+        if (-not [string]::IsNullOrWhiteSpace($envFlags)) {
+            foreach ($line in @($envFlags -split "(`r`n|`n|`r)")) {
+                if (-not [string]::IsNullOrWhiteSpace($line)) {
+                    $resolved.Add($line.Trim()) | Out-Null
+                }
+            }
+        }
+    }
+
+    foreach ($flag in @($FlagValues)) {
+        if (-not [string]::IsNullOrWhiteSpace($flag)) {
+            $resolved.Add($flag.Trim()) | Out-Null
+        }
+    }
+
+    return @($resolved | Select-Object -Unique)
+}
+
+function Resolve-HostedCompareScriptsRoot {
+    $scriptsRoot = [System.Environment]::GetEnvironmentVariable('COMPAREVI_SCRIPTS_ROOT', 'Process')
+    if ([string]::IsNullOrWhiteSpace($scriptsRoot)) {
+        throw 'COMPAREVI_SCRIPTS_ROOT was not set by comparevi-history. This adapter must run through the facade.'
+    }
+
+    $resolved = [System.IO.Path]::GetFullPath($scriptsRoot)
+    if (-not (Test-Path -LiteralPath $resolved -PathType Container)) {
+        throw "COMPAREVI_SCRIPTS_ROOT does not exist: $resolved"
+    }
+
+    return $resolved
+}
+
+function Resolve-HostedCompareRunner {
+    param([Parameter(Mandatory = $true)][string]$ScriptsRoot)
+
+    $runnerScript = Join-Path $ScriptsRoot 'tools' 'Run-NILinuxContainerCompare.ps1'
+    if (-not (Test-Path -LiteralPath $runnerScript -PathType Leaf)) {
+        throw "Run-NILinuxContainerCompare.ps1 not found at '$runnerScript'."
+    }
+
+    return $runnerScript
+}
+
+function Resolve-ReportExtension {
+    param([Parameter(Mandatory = $true)][string]$ReportTypeValue)
+
+    switch ($ReportTypeValue) {
+        'xml' { return 'xml' }
+        'text' { return 'txt' }
+        default { return 'html' }
+    }
+}
+
+function Copy-IfExists {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourcePath,
+        [Parameter(Mandatory = $true)][string]$DestinationPath
+    )
+
+    if (-not (Test-Path -LiteralPath $SourcePath -PathType Leaf)) {
+        return $false
+    }
+
+    Copy-Item -LiteralPath $SourcePath -Destination $DestinationPath -Force
+    return $true
+}
+
+function New-NormalizedCapture {
+    param(
+        [AllowNull()][psobject]$RunnerCapture,
+        [Parameter(Mandatory = $true)][string]$Image,
+        [Parameter(Mandatory = $true)][string]$BaseViPath,
+        [Parameter(Mandatory = $true)][string]$HeadViPath,
+        [Parameter(Mandatory = $true)][string]$ReportPathValue,
+        [Parameter(Mandatory = $true)][string]$CapturePathValue,
+        [Parameter(Mandatory = $true)][string]$StdOutPathValue,
+        [Parameter(Mandatory = $true)][string]$StdErrPathValue,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$ResolvedFlags
+    )
+
+    $reportSize = if (Test-Path -LiteralPath $ReportPathValue -PathType Leaf) {
+        [int64](Get-Item -LiteralPath $ReportPathValue).Length
+    } else {
+        [int64]0
+    }
+
+    $isDiff = $false
+    if ($null -ne $RunnerCapture) {
+        if ($RunnerCapture.PSObject.Properties['diff']) {
+            $isDiff = [bool]$RunnerCapture.diff
+        } elseif ($RunnerCapture.PSObject.Properties['isDiff']) {
+            $isDiff = [bool]$RunnerCapture.isDiff
+        } elseif ($RunnerCapture.PSObject.Properties['exitCode']) {
+            $isDiff = ([int]$RunnerCapture.exitCode -eq 1)
+        }
+    }
+
+    return [ordered]@{
+        schema = 'lvcompare-capture/v1'
+        generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+        command = if ($null -ne $RunnerCapture -and $RunnerCapture.PSObject.Properties['command']) { [string]$RunnerCapture.command } else { '' }
+        cliPath = "docker:$Image"
+        exitCode = if ($null -ne $RunnerCapture -and $RunnerCapture.PSObject.Properties['exitCode']) { [int]$RunnerCapture.exitCode } else { $null }
+        diff = $isDiff
+        isDiff = $isDiff
+        base = $BaseViPath
+        head = $HeadViPath
+        reportPath = $ReportPathValue
+        stdoutPath = $StdOutPathValue
+        stderrPath = $StdErrPathValue
+        normalizedFrom = $CapturePathValue
+        args = @($ResolvedFlags)
+        environment = [ordered]@{
+            cli = [ordered]@{
+                image = $Image
+                artifacts = [ordered]@{
+                    imageCount = 0
+                    images = @()
+                    reportSizeBytes = $reportSize
+                }
+            }
+        }
+        runnerCapture = $RunnerCapture
+    }
+}
+
+$scriptsRoot = Resolve-HostedCompareScriptsRoot
+$runnerScript = Resolve-HostedCompareRunner -ScriptsRoot $scriptsRoot
+$reportType = Resolve-HostedCompareReportType -ReportFormatValue $ReportFormat -RenderReportValue:$RenderReport
+$reportExtension = Resolve-ReportExtension -ReportTypeValue $reportType
+$outputDirResolved = Resolve-OutputDirectory -PathValue $OutputDir
+$baseViResolved = Resolve-AbsolutePath -PathValue $BaseVi -BasePath (Get-Location).Path
+$headViResolved = Resolve-AbsolutePath -PathValue $HeadVi -BasePath (Get-Location).Path
+$reportPathResolved = Join-Path $outputDirResolved ("compare-report.{0}" -f $reportExtension)
+$image = if ([string]::IsNullOrWhiteSpace($env:COMPAREVI_NI_LINUX_IMAGE)) {
+    'nationalinstruments/labview:2026q1-linux'
+} else {
+    $env:COMPAREVI_NI_LINUX_IMAGE.Trim()
+}
+
+New-Item -ItemType Directory -Path $outputDirResolved -Force | Out-Null
+
+$resolvedFlags = @(Resolve-HostedCompareFlags -FlagValues $Flags -ReplaceFlagsValue:$ReplaceFlags)
+$runnerArgs = @{
+    BaseVi = $baseViResolved
+    HeadVi = $headViResolved
+    Image = $image
+    ReportPath = $reportPathResolved
+    ReportType = $reportType
+}
+if ($null -ne $TimeoutSeconds -and [int]$TimeoutSeconds -gt 0) {
+    $runnerArgs.TimeoutSeconds = [int]$TimeoutSeconds
+}
+if ($resolvedFlags.Count -gt 0) {
+    $runnerArgs.Flags = @($resolvedFlags)
+}
+if ($Quiet.IsPresent) {
+    $runnerArgs.HeartbeatSeconds = 30
+}
+
+$runnerCapture = & $runnerScript @runnerArgs -PassThru
+$runnerExitCode = $LASTEXITCODE
+
+$niCapturePath = Join-Path $outputDirResolved 'ni-linux-container-capture.json'
+$niStdOutPath = Join-Path $outputDirResolved 'ni-linux-container-stdout.txt'
+$niStdErrPath = Join-Path $outputDirResolved 'ni-linux-container-stderr.txt'
+$lvCapturePath = Join-Path $outputDirResolved 'lvcompare-capture.json'
+$lvStdOutPath = Join-Path $outputDirResolved 'lvcompare-stdout.txt'
+$lvStdErrPath = Join-Path $outputDirResolved 'lvcompare-stderr.txt'
+
+[void](Copy-IfExists -SourcePath $niStdOutPath -DestinationPath $lvStdOutPath)
+[void](Copy-IfExists -SourcePath $niStdErrPath -DestinationPath $lvStdErrPath)
+
+if ((Test-Path -LiteralPath $niCapturePath -PathType Leaf)) {
+    try {
+        $runnerCapture = Get-Content -LiteralPath $niCapturePath -Raw | ConvertFrom-Json -Depth 8
+    } catch {
+        # Keep the direct object if the file cannot be parsed.
+    }
+}
+
+$normalizedCapture = New-NormalizedCapture `
+    -RunnerCapture $runnerCapture `
+    -Image $image `
+    -BaseViPath $baseViResolved `
+    -HeadViPath $headViResolved `
+    -ReportPathValue $reportPathResolved `
+    -CapturePathValue $niCapturePath `
+    -StdOutPathValue $lvStdOutPath `
+    -StdErrPathValue $lvStdErrPath `
+    -ResolvedFlags $resolvedFlags
+
+$normalizedCapture | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $lvCapturePath -Encoding utf8
+
+if ($runnerExitCode -ne 0) {
+    exit $runnerExitCode
+}

--- a/Tooling/tests/Invoke-CompareVIHistoryHostedNILinux.Tests.ps1
+++ b/Tooling/tests/Invoke-CompareVIHistoryHostedNILinux.Tests.ps1
@@ -1,0 +1,87 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+Describe 'Invoke-CompareVIHistoryHostedNILinux.ps1' -Tag 'Unit' {
+    BeforeAll {
+        $script:RepoRoot = Split-Path -Parent $PSScriptRoot
+        $script:ScriptPath = Join-Path $script:RepoRoot 'Invoke-CompareVIHistoryHostedNILinux.ps1'
+        if (-not (Test-Path -LiteralPath $script:ScriptPath -PathType Leaf)) {
+            throw "Invoke-CompareVIHistoryHostedNILinux.ps1 not found at $script:ScriptPath"
+        }
+    }
+
+    It 'normalizes NI Linux container artifacts into the lvcompare capture surface' {
+        $toolsRoot = Join-Path $TestDrive 'comparevi-tools'
+        $backendTools = Join-Path $toolsRoot 'tools'
+        $runnerScript = Join-Path $backendTools 'Run-NILinuxContainerCompare.ps1'
+        $outputDir = Join-Path $TestDrive 'out'
+        $baseVi = Join-Path $TestDrive 'Base.vi'
+        $headVi = Join-Path $TestDrive 'Head.vi'
+
+        New-Item -ItemType Directory -Path $backendTools -Force | Out-Null
+        Set-Content -LiteralPath $baseVi -Value 'base' -Encoding utf8
+        Set-Content -LiteralPath $headVi -Value 'head' -Encoding utf8
+        Set-Content -LiteralPath $runnerScript -Encoding utf8 -Value @'
+param(
+  [string]$BaseVi,
+  [string]$HeadVi,
+  [string]$Image,
+  [string]$ReportPath,
+  [string]$ReportType,
+  [int]$TimeoutSeconds,
+  [string[]]$Flags,
+  [switch]$PassThru
+)
+$outDir = Split-Path -Parent $ReportPath
+New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+'<html><body><details open><summary class="difference-heading">diff</summary></details></body></html>' | Set-Content -LiteralPath $ReportPath -Encoding utf8
+'stdout' | Set-Content -LiteralPath (Join-Path $outDir 'ni-linux-container-stdout.txt') -Encoding utf8
+'stderr' | Set-Content -LiteralPath (Join-Path $outDir 'ni-linux-container-stderr.txt') -Encoding utf8
+[ordered]@{
+  schema = 'ni-linux-container-compare/v1'
+  command = 'docker run test'
+  exitCode = 1
+  isDiff = $true
+  reportPath = $ReportPath
+} | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $outDir 'ni-linux-container-capture.json') -Encoding utf8
+if ($PassThru) {
+  [pscustomobject]@{
+    command = 'docker run test'
+    exitCode = 1
+    isDiff = $true
+  }
+}
+exit 1
+'@
+
+        $env:COMPAREVI_SCRIPTS_ROOT = $toolsRoot
+        $env:COMPAREVI_NI_LINUX_IMAGE = 'nationalinstruments/labview:2026q1-linux'
+        try {
+            & pwsh -NoLogo -NoProfile -File $script:ScriptPath `
+                -BaseVi $baseVi `
+                -HeadVi $headVi `
+                -OutputDir $outputDir `
+                -Quiet
+
+            $LASTEXITCODE | Should -Be 1
+
+            $capturePath = Join-Path $outputDir 'lvcompare-capture.json'
+            $stdoutPath = Join-Path $outputDir 'lvcompare-stdout.txt'
+            $stderrPath = Join-Path $outputDir 'lvcompare-stderr.txt'
+
+            $capturePath | Should -Exist
+            $stdoutPath | Should -Exist
+            $stderrPath | Should -Exist
+
+            $capture = Get-Content -LiteralPath $capturePath -Raw | ConvertFrom-Json -Depth 10
+            $capture.exitCode | Should -Be 1
+            $capture.diff | Should -BeTrue
+            $capture.cliPath | Should -Be 'docker:nationalinstruments/labview:2026q1-linux'
+            $capture.environment.cli.artifacts.reportSizeBytes | Should -BeGreaterThan 0
+        }
+        finally {
+            Remove-Item Env:COMPAREVI_SCRIPTS_ROOT -ErrorAction SilentlyContinue
+            Remove-Item Env:COMPAREVI_NI_LINUX_IMAGE -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This directory collects guides and references for working with the LabVIEW Icon 
 - [PowerShell CLI GitHub Action Instructions](powershell-cli-github-action-instructions.md)
 - [PowerShell Dependency Scripts](powershell-dependency-scripts.md)
 - [CI Workflows Overview](ci-workflows.md)
+- [CompareVI History Diagnostics](comparevi-history-diagnostics.md)
 
 ## CI and Advanced Topics
 

--- a/docs/comparevi-history-diagnostics.md
+++ b/docs/comparevi-history-diagnostics.md
@@ -1,0 +1,58 @@
+# CompareVI History Diagnostics
+
+This repository can consume `comparevi-history` as a released diagnostics facade for pull-request review without
+running that facade directly from untrusted PR events.
+
+## Workflows
+
+- [`.github/workflows/comparevi-history-manual-pr-diagnostics.yml`](../.github/workflows/comparevi-history-manual-pr-diagnostics.yml)
+  is a maintainer-dispatched workflow for inspecting a specific pull request and repository-relative VI path on demand.
+- [`.github/workflows/comparevi-history-comment-gated.yml`](../.github/workflows/comparevi-history-comment-gated.yml)
+  is a maintainer-only slash-command workflow that runs when a trusted maintainer comments
+  `/comparevi-history <repository-relative-vi-path> [--modes comma,list]` on a pull request.
+
+Both workflows:
+
+- use released `LabVIEW-Community-CI-CD/comparevi-history` refs only
+- run on `ubuntu-latest`
+- pre-pull `nationalinstruments/labview:2026q1-linux` under a repo-level concurrency group so image acquisition and
+  compare execution stay serialized
+- resolve the PR head repository and SHA dynamically
+- use the repo-local `Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1` adapter as a maintainer-controlled
+  `invoke_script_path`
+- upload diagnostics artifacts plus reviewer-facing mode summaries
+
+## Release Contract
+
+- Consumer workflows in this repository must pin released `comparevi-history` refs only.
+- Consumers in this repository must not pin `compare-vi-cli-action` directly.
+- The normal released `comparevi-history` path already resolves its backend from the released
+  `compare-vi-cli-action` bundle mapping.
+- Consumer workflows here should not set maintainer-only backend override inputs such as `comparevi_repository` or
+  `comparevi_ref`.
+- The hosted invoke adapter resolves `Run-NILinuxContainerCompare.ps1` from `COMPAREVI_SCRIPTS_ROOT`, which is exported
+  by the released facade while it runs the released backend bundle.
+
+## Upstream and Fork Alignment
+
+- The canonical upstream repo for this diagnostics shape is `LabVIEW-Community-CI-CD/labview-icon-editor-demo`.
+- Downstream forks such as `svelderrainruiz/labview-icon-editor-demo` should keep these workflow files aligned to
+  upstream unless they intentionally diverge on diagnostics policy.
+- The workflows are repo-local by design: they query the pull request from the current repository, then check out the
+  PR head repo and SHA exactly as reported by the GitHub API.
+
+## Recommended Usage
+
+1. Start with the manual workflow when you want a low-risk maintainer-controlled diagnostics path.
+2. Use a stable VI path such as `Tooling/deployment/VIP_Post-Install Custom Action.vi` while validating hosted-runner
+   and trust behavior.
+3. Add the comment-gated workflow once maintainers are comfortable triggering diagnostics from PR comments on the
+   hosted runner under maintainer-only command gating.
+4. Keep the default mode bundle `default,attributes,front-panel,block-diagram` unless there is a documented reason to
+   narrow it.
+
+## See Also
+
+- [CI Workflows Overview](ci-workflows.md)
+- [Documentation Index](README.md)
+- [`comparevi-history` safe public template guidance](https://github.com/LabVIEW-Community-CI-CD/comparevi-history/blob/main/docs/SAFE_PR_DIAGNOSTICS_TEMPLATES.md)


### PR DESCRIPTION
# GitHub Issue for the Pull Request
- LabVIEW-Community-CI-CD/compare-vi-cli-action#930

# GitHub Discussions Related to this Pull Request
- None

# Checklists
- [x] I do not require assistance from NI to complete any of the following checks.
- [x] The changes in this PR are based on the appropriate feature branch for this repository.
- [x] I am submitting the changes in this PR to the appropriate default branch for this repository.
- [ ] I built a VI Package using the Powershell build tool.
- [ ] I installed the VI Package produced by the Powershell build tool and tested my change.
- [ ] I tested my changes after installing the VI package.
- [ ] NI has my contributor license agreement.

# Summary of Changes
This PR adds a fork-ready `comparevi-history` diagnostics surface that runs on `ubuntu-latest` instead of the self-hosted LabVIEW runner. It introduces two maintainer-triggered workflows, a repo-local hosted NI Linux invoke adapter, and documentation that explains how the released facade resolves the released `compare-vi-cli-action` backend without pinning backend refs directly in this repository.

# Reason for Change
The diagnostics path needs to be usable by downstream forks and demo consumers without depending on privileged self-hosted runner labels. Using a hosted runner with serial `nationalinstruments/labview:2026q1-linux` pulls gives this repository a safer public adoption surface while preserving maintainer-only gating for PR diagnostics.

# Visual Aids
None.

# Additional Information
- The workflows pin released `LabVIEW-Community-CI-CD/comparevi-history` refs only.
- The repo-local adapter uses the facade-exported `COMPAREVI_SCRIPTS_ROOT` seam to call the released `Run-NILinuxContainerCompare.ps1` backend.
- The comment-gated workflow stays maintainer-only through `author_association` validation.

# Testing
## Manual Tests
- `Invoke-Pester -Path 'Tooling/tests/Invoke-CompareVIHistoryHostedNILinux.Tests.ps1' -CI`
- `D:\workspace\compare-vi-cli-action\compare-vi-cli-action\bin\actionlint.exe -color .github/workflows/comparevi-history-manual-pr-diagnostics.yml .github/workflows/comparevi-history-comment-gated.yml`
