### PR TITLE
#4 Adopt comparevi-history platform boundary

### DIFF
--- a/.github/comparevi-history-targets.json
+++ b/.github/comparevi-history-targets.json
@@ -1,0 +1,27 @@
+{
+  "schema": "comparevi-history/consumer-targets@v1",
+  "defaultTargetId": "vip-post-install-custom-action",
+  "targets": [
+    {
+      "id": "vip-post-install-custom-action",
+      "path": "Tooling/deployment/VIP_Post-Install Custom Action.vi",
+      "publicModes": [
+        "attributes",
+        "front-panel",
+        "block-diagram"
+      ],
+      "history": {
+        "branchBudget": {
+          "maxCommitCount": 64
+        }
+      },
+      "reviewerSurface": {
+        "variants": [
+          "manual",
+          "comment-gated"
+        ],
+        "commentCommand": "/comparevi-history vip-post-install-custom-action --modes attributes,front-panel,block-diagram"
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,7 @@ jobs:
         run: |
           $testFiles = @(
             'Tooling/tests/CiPipelineCompositeContract.Tests.ps1',
+            'Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1',
             'Tooling/tests/PylaviCompositeContract.Tests.ps1',
             'Tooling/tests/ViAnalyzerCompositeContract.Tests.ps1'
           )

--- a/.github/workflows/comparevi-history-comment-gated.yml
+++ b/.github/workflows/comparevi-history-comment-gated.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      DEFAULT_COMPARE_MODES: default,attributes,front-panel,block-diagram
-      DEFAULT_MAX_PAIRS: "5"
-      DEFAULT_MAX_SIGNAL_PAIRS: "5"
-      FACADE_REF: v1.0.4
+      DEFAULT_COMPARE_MODES: attributes,front-panel,block-diagram
+      DEFAULT_MAX_PAIRS: '5'
+      DEFAULT_MAX_SIGNAL_PAIRS: '5'
+      FACADE_REF: v1.1.0
       COMPAREVI_NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
     steps:
       - name: Validate maintainer command and resolve PR head
@@ -51,20 +51,20 @@ jobs:
 
           $remainder = $command.Substring($prefix.Length).Trim()
           if ([string]::IsNullOrWhiteSpace($remainder)) {
-            throw 'Usage: /comparevi-history <repository-relative-vi-path> [--modes comma,list]'
+            throw 'Usage: /comparevi-history <target-id> [--modes attributes,front-panel,block-diagram]'
           }
 
-          $targetPath = $remainder
+          $targetId = $remainder
           $compareModes = $env:DEFAULT_COMPARE_MODES
           $modeMarker = ' --modes '
           $modeIndex = $remainder.IndexOf($modeMarker, [System.StringComparison]::OrdinalIgnoreCase)
           if ($modeIndex -ge 0) {
-            $targetPath = $remainder.Substring(0, $modeIndex).Trim()
+            $targetId = $remainder.Substring(0, $modeIndex).Trim()
             $compareModes = $remainder.Substring($modeIndex + $modeMarker.Length).Trim()
           }
 
-          if ([string]::IsNullOrWhiteSpace($targetPath)) {
-            throw 'The slash command must include a repository-relative VI path.'
+          if ([string]::IsNullOrWhiteSpace($targetId)) {
+            throw 'The slash command must include a comparevi-history target identifier.'
           }
           if ([string]::IsNullOrWhiteSpace($compareModes)) {
             $compareModes = $env:DEFAULT_COMPARE_MODES
@@ -84,13 +84,19 @@ jobs:
           }
 
           @(
-            "target-path=$targetPath"
+            "target-id=$targetId"
             "compare-modes=$compareModes"
             "head-repo=$($pr.head.repo.full_name)"
             "head-sha=$($pr.head.sha)"
             "head-ref=$($pr.head.ref)"
             "is-fork=$([bool]$pr.head.repo.fork)"
           ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Checkout trusted consumer contract
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          path: trusted-consumer
 
       - name: Pre-pull NI Linux image
         shell: bash
@@ -101,14 +107,20 @@ jobs:
         with:
           repository: ${{ steps.request.outputs['head-repo'] }}
           ref: ${{ steps.request.outputs['head-sha'] }}
+          path: pr-head
           fetch-depth: 0
 
       - name: Run comparevi-history
         id: history
-        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.0.4
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.1.0
         with:
-          target_path: ${{ steps.request.outputs['target-path'] }}
+          repository_root: pr-head
+          target_spec_path: ${{ github.workspace }}/trusted-consumer/.github/comparevi-history-targets.json
+          target_id: ${{ steps.request.outputs['target-id'] }}
           start_ref: ${{ steps.request.outputs['head-sha'] }}
+          source_branch_ref: ${{ steps.request.outputs['head-ref'] }}
+          consumer_repository: ${{ steps.request.outputs['head-repo'] }}
+          consumer_ref: ${{ steps.request.outputs['head-sha'] }}
           mode: ${{ steps.request.outputs['compare-modes'] }}
           max_pairs: ${{ env.DEFAULT_MAX_PAIRS }}
           max_signal_pairs: ${{ env.DEFAULT_MAX_SIGNAL_PAIRS }}
@@ -116,7 +128,12 @@ jobs:
           detailed: true
           fail_on_diff: false
           results_dir: tests/results/pr-diagnostics/history
-          invoke_script_path: Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1
+          reviewer_surface: comment-gated
+          reviewer_issue_number: ${{ github.event.issue.number }}
+          reviewer_pull_request_number: ${{ github.event.issue.number }}
+          reviewer_is_fork: ${{ steps.request.outputs['is-fork'] }}
+          container_image: ${{ env.COMPAREVI_NI_LINUX_IMAGE }}
+          invoke_script_path: ${{ github.workspace }}/trusted-consumer/Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1
 
       - name: Upload diagnostics artifacts
         if: ${{ always() && steps.history.outputs['results-dir'] != '' }}
@@ -126,21 +143,27 @@ jobs:
           path: ${{ steps.history.outputs['results-dir'] }}/**
           if-no-files-found: error
 
-      - name: Publish diagnostics summary
-        if: ${{ always() }}
+      - name: Append action-owned step summary
+        if: ${{ always() && steps.history.outputs['public-step-summary-path'] != '' }}
+        shell: pwsh
+        env:
+          PUBLIC_STEP_SUMMARY_PATH: ${{ steps.history.outputs['public-step-summary-path'] }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          if (-not (Test-Path -LiteralPath $env:PUBLIC_STEP_SUMMARY_PATH -PathType Leaf)) {
+            throw "comparevi-history public step summary was missing: $($env:PUBLIC_STEP_SUMMARY_PATH)"
+          }
+          Get-Content -LiteralPath $env:PUBLIC_STEP_SUMMARY_PATH -Raw | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+      - name: Publish diagnostics PR comment
+        if: ${{ always() && steps.history.outputs['public-comment-path'] != '' }}
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.0.4
-          TARGET_PATH: ${{ steps.request.outputs['target-path'] }}
-          REQUESTED_MODES: ${{ steps.history.outputs['requested-mode-list'] }}
-          EXECUTED_MODES: ${{ steps.history.outputs['executed-mode-list'] }}
-          TOTAL_PROCESSED: ${{ steps.history.outputs['total-processed'] }}
-          TOTAL_DIFFS: ${{ steps.history.outputs['total-diffs'] }}
-          MODE_SUMMARY_MARKDOWN: ${{ steps.history.outputs['mode-summary-markdown'] }}
-          STEP_CONCLUSION: ${{ steps.history.conclusion }}
-          IS_FORK: ${{ steps.request.outputs['is-fork'] }}
+          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1.1.0
+          COMMENT_PATH: ${{ steps.history.outputs['public-comment-path'] }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
@@ -152,47 +175,11 @@ jobs:
             'X-GitHub-Api-Version' = '2022-11-28'
           }
 
-          $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
-          $summaryLines = @(
-            '## comparevi-history comment-gated diagnostics'
-            ''
-            ('- Action ref: `{0}`' -f $env:ACTION_REF)
-            ('- Pull request: `#{0}`' -f $env:ISSUE_NUMBER)
-            ('- Target path: `{0}`' -f $env:TARGET_PATH)
-            ('- Container image: `{0}`' -f $env:COMPAREVI_NI_LINUX_IMAGE)
-            ('- Requested modes: `{0}`' -f $env:REQUESTED_MODES)
-            ('- Executed modes: `{0}`' -f $env:EXECUTED_MODES)
-            ('- Total processed: `{0}`' -f $env:TOTAL_PROCESSED)
-            ('- Total diffs: `{0}`' -f $env:TOTAL_DIFFS)
-            ('- Step conclusion: `{0}`' -f $env:STEP_CONCLUSION)
-            ('- PR head is fork: `{0}`' -f $env:IS_FORK)
-            ('- Run URL: {0}' -f $runUrl)
-            ''
-            '### Mode coverage'
-            ''
-            $env:MODE_SUMMARY_MARKDOWN
-          )
-          $summaryLines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          if (-not (Test-Path -LiteralPath $env:COMMENT_PATH -PathType Leaf)) {
+            throw "comparevi-history public comment body was missing: $($env:COMMENT_PATH)"
+          }
 
-          $body = @"
-          comparevi-history diagnostics finished for PR #$env:ISSUE_NUMBER.
-
-          - Action ref: `$env:ACTION_REF`
-          - Target path: `$env:TARGET_PATH`
-          - Container image: `$env:COMPAREVI_NI_LINUX_IMAGE`
-          - Requested modes: `$env:REQUESTED_MODES`
-          - Executed modes: `$env:EXECUTED_MODES`
-          - Total processed: `$env:TOTAL_PROCESSED`
-          - Total diffs: `$env:TOTAL_DIFFS`
-          - Step conclusion: `$env:STEP_CONCLUSION`
-          - PR head is fork: `$env:IS_FORK`
-
-          ### Mode coverage
-          $env:MODE_SUMMARY_MARKDOWN
-
-          - Run: $runUrl
-          "@.Trim()
-
+          $body = Get-Content -LiteralPath $env:COMMENT_PATH -Raw
           $payload = @{ body = $body } | ConvertTo-Json -Depth 5
           $uri = "https://api.github.com/repos/$env:GITHUB_REPOSITORY/issues/$env:ISSUE_NUMBER/comments"
 

--- a/.github/workflows/comparevi-history-manual-pr-diagnostics.yml
+++ b/.github/workflows/comparevi-history-manual-pr-diagnostics.yml
@@ -7,24 +7,24 @@ on:
         description: Pull request number to inspect
         required: true
         type: string
-      target_path:
-        description: Repository-relative VI path to inspect
+      target_id:
+        description: comparevi-history target identifier from .github/comparevi-history-targets.json
         required: true
         type: string
       compare_modes:
-        description: Comma-separated compare mode bundle
+        description: Optional comma-separated explicit mode list override
         required: false
-        default: default,attributes,front-panel,block-diagram
+        default: attributes,front-panel,block-diagram
         type: string
       max_pairs:
         description: Maximum adjacent commit pairs to process
         required: false
-        default: "5"
+        default: '5'
         type: string
       max_signal_pairs:
         description: Maximum surfaced signal pairs
         required: false
-        default: "5"
+        default: '5'
         type: string
 
 permissions:
@@ -72,6 +72,12 @@ jobs:
             "is-fork=$([bool]$pr.head.repo.fork)"
           ) | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
+      - name: Checkout trusted consumer contract
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          path: trusted-consumer
+
       - name: Pre-pull NI Linux image
         shell: bash
         run: docker pull "$COMPAREVI_NI_LINUX_IMAGE"
@@ -81,14 +87,20 @@ jobs:
         with:
           repository: ${{ steps.pr.outputs['head-repo'] }}
           ref: ${{ steps.pr.outputs['head-sha'] }}
+          path: pr-head
           fetch-depth: 0
 
       - name: Run comparevi-history
         id: history
-        uses: LabVIEW-Community-CI-CD/comparevi-history@v1
+        uses: LabVIEW-Community-CI-CD/comparevi-history@v1.1.0
         with:
-          target_path: ${{ inputs.target_path }}
+          repository_root: pr-head
+          target_spec_path: ${{ github.workspace }}/trusted-consumer/.github/comparevi-history-targets.json
+          target_id: ${{ inputs.target_id }}
           start_ref: ${{ steps.pr.outputs['head-sha'] }}
+          source_branch_ref: ${{ steps.pr.outputs['head-ref'] }}
+          consumer_repository: ${{ steps.pr.outputs['head-repo'] }}
+          consumer_ref: ${{ steps.pr.outputs['head-sha'] }}
           mode: ${{ inputs.compare_modes }}
           max_pairs: ${{ inputs.max_pairs }}
           max_signal_pairs: ${{ inputs.max_signal_pairs }}
@@ -96,7 +108,11 @@ jobs:
           detailed: true
           fail_on_diff: false
           results_dir: tests/results/pr-diagnostics/history
-          invoke_script_path: Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1
+          reviewer_surface: manual
+          reviewer_pull_request_number: ${{ inputs.pull_request_number }}
+          reviewer_is_fork: ${{ steps.pr.outputs['is-fork'] }}
+          container_image: ${{ env.COMPAREVI_NI_LINUX_IMAGE }}
+          invoke_script_path: ${{ github.workspace }}/trusted-consumer/Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1
 
       - name: Upload diagnostics artifacts
         if: ${{ always() && steps.history.outputs['results-dir'] != '' }}
@@ -106,41 +122,15 @@ jobs:
           path: ${{ steps.history.outputs['results-dir'] }}/**
           if-no-files-found: error
 
-      - name: Summarize diagnostics
-        if: ${{ always() }}
+      - name: Append action-owned step summary
+        if: ${{ always() && steps.history.outputs['public-step-summary-path'] != '' }}
         shell: pwsh
         env:
-          ACTION_REF: LabVIEW-Community-CI-CD/comparevi-history@v1
-          PR_NUMBER: ${{ inputs.pull_request_number }}
-          TARGET_PATH: ${{ inputs.target_path }}
-          REQUESTED_MODES: ${{ steps.history.outputs['requested-mode-list'] }}
-          EXECUTED_MODES: ${{ steps.history.outputs['executed-mode-list'] }}
-          TOTAL_PROCESSED: ${{ steps.history.outputs['total-processed'] }}
-          TOTAL_DIFFS: ${{ steps.history.outputs['total-diffs'] }}
-          RESULTS_DIR: ${{ steps.history.outputs['results-dir'] }}
-          MODE_SUMMARY_MARKDOWN: ${{ steps.history.outputs['mode-summary-markdown'] }}
-          IS_FORK: ${{ steps.pr.outputs['is-fork'] }}
+          PUBLIC_STEP_SUMMARY_PATH: ${{ steps.history.outputs['public-step-summary-path'] }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
-
-          $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
-          @(
-            '## comparevi-history manual PR diagnostics'
-            ''
-            ('- Action ref: `{0}`' -f $env:ACTION_REF)
-            ('- Pull request: `#{0}`' -f $env:PR_NUMBER)
-            ('- Target path: `{0}`' -f $env:TARGET_PATH)
-            ('- Container image: `{0}`' -f $env:COMPAREVI_NI_LINUX_IMAGE)
-            ('- Requested modes: `{0}`' -f $env:REQUESTED_MODES)
-            ('- Executed modes: `{0}`' -f $env:EXECUTED_MODES)
-            ('- Total processed: `{0}`' -f $env:TOTAL_PROCESSED)
-            ('- Total diffs: `{0}`' -f $env:TOTAL_DIFFS)
-            ('- Results dir: `{0}`' -f $env:RESULTS_DIR)
-            ('- PR head is fork: `{0}`' -f $env:IS_FORK)
-            ('- Run URL: {0}' -f $runUrl)
-            ''
-            '### Mode coverage'
-            ''
-            $env:MODE_SUMMARY_MARKDOWN
-          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+          if (-not (Test-Path -LiteralPath $env:PUBLIC_STEP_SUMMARY_PATH -PathType Leaf)) {
+            throw "comparevi-history public step summary was missing: $($env:PUBLIC_STEP_SUMMARY_PATH)"
+          }
+          Get-Content -LiteralPath $env:PUBLIC_STEP_SUMMARY_PATH -Raw | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ For additional details and troubleshooting tips, see [INSTALL.md](INSTALL.md).
    - **Build VI Package** – Compiles the source and produces a `.vip` artifact (VI Package).
    - **Run Unit Tests** (now part of the main CI pipeline) – Executes automated tests to verify the Icon Editor’s behavior in a clean LabVIEW environment.
    - **CompareVI History Diagnostics** – Maintainer-triggered workflows can inspect released `comparevi-history`
-     diagnostics for pull requests without exposing the facade to untrusted PR events.
+     diagnostics for pull requests through a checked-in target catalog and action-owned reviewer outputs without
+     exposing the platform to untrusted PR events.
    Additional details on these pipelines are in [CI Workflows](docs/ci-workflows.md) and the [CI Workflow (Multi-Channel Release Support)](docs/powershell-cli-github-action-instructions.md).
 
 ---
@@ -114,7 +115,8 @@ For very large or long-term contributions, NI may use an `experiment/<feature-na
 In-depth documentation and reference guides are located in the `/docs` directory. A complete index is available in [docs/README.md](docs/README.md). Notable documents include:
 
 - **Build & CI Guides:** How to build the Icon Editor and use continuous integration tools. For local setup, see [manual-instructions.md](docs/manual-instructions.md) or the script-driven [automated-setup.md](docs/automated-setup.md). CI pipelines are covered in [CI Workflows](docs/ci-workflows.md) and the [CI Workflow (Multi-Channel Release Support)](docs/powershell-cli-github-action-instructions.md). Reference scripts are listed in [PowerShell Dependency Scripts](docs/powershell-dependency-scripts.md). Packaging and runner configuration are detailed in [Build VI Package](docs/ci/actions/build-vi-package.md) and the [Runner Setup Guide](docs/ci/actions/runner-setup-guide.md).
-- **PR Diagnostics:** Released-ref PR diagnostics guidance for maintainers and downstream forks is documented in
+- **PR Diagnostics:** Released-ref PR diagnostics guidance for maintainers and downstream forks, including the checked-in
+  comparevi-history target catalog and reviewer-surface contract, is documented in
   [CompareVI History Diagnostics](docs/comparevi-history-diagnostics.md).
 - **Composite Actions:** Summary of the repository's reusable GitHub Actions is available in [Composite Actions](docs/ci/actions/README.md).
 - **Advanced Workflows:** Details on complex release processes and branching strategies. For example, the [Multichannel Release Workflow](docs/ci/actions/multichannel-release-workflow.md) explains alpha/beta/RC release branches, and [EXPERIMENTS.md](docs/ci/experiments.md) covers long-running feature branches. Maintainers can refer to the [Maintainer's Guide](docs/ci/actions/maintainers-guide.md) for internal release duties.

--- a/Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1
+++ b/Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1
@@ -1,0 +1,86 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'CompareVI History workflow contracts' {
+    BeforeAll {
+        $repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..')).Path
+        $script:manualWorkflowPath = Join-Path $repoRoot '.github/workflows/comparevi-history-manual-pr-diagnostics.yml'
+        $script:commentWorkflowPath = Join-Path $repoRoot '.github/workflows/comparevi-history-comment-gated.yml'
+        $script:targetCatalogPath = Join-Path $repoRoot '.github/comparevi-history-targets.json'
+        $script:docsPath = Join-Path $repoRoot 'docs/comparevi-history-diagnostics.md'
+
+        foreach ($path in @($script:manualWorkflowPath, $script:commentWorkflowPath, $script:targetCatalogPath, $script:docsPath)) {
+            if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+                throw "Required comparevi-history contract file not found: $path"
+            }
+        }
+
+        $script:manualWorkflow = Get-Content -LiteralPath $script:manualWorkflowPath -Raw
+        $script:commentWorkflow = Get-Content -LiteralPath $script:commentWorkflowPath -Raw
+        $script:targetCatalog = Get-Content -LiteralPath $script:targetCatalogPath -Raw
+        $script:docs = Get-Content -LiteralPath $script:docsPath -Raw
+    }
+
+    It 'checks in a v1 consumer target catalog with an explicit public-mode contract' {
+        $script:targetCatalog | Should -Match '"schema"\s*:\s*"comparevi-history/consumer-targets@v1"'
+        $script:targetCatalog | Should -Match '"defaultTargetId"\s*:\s*"vip-post-install-custom-action"'
+        $script:targetCatalog | Should -Match '"path"\s*:\s*"Tooling/deployment/VIP_Post-Install Custom Action\.vi"'
+        $script:targetCatalog | Should -Match '"publicModes"\s*:\s*\[\s*"attributes"\s*,\s*"front-panel"\s*,\s*"block-diagram"\s*\]'
+        $script:targetCatalog | Should -Match '"commentCommand"\s*:\s*"/comparevi-history vip-post-install-custom-action --modes attributes,front-panel,block-diagram"'
+        $script:targetCatalog | Should -Not -Match '"default"'
+        $script:targetCatalog | Should -Not -Match '"full"'
+        $script:targetCatalog | Should -Not -Match '"all"'
+    }
+
+    It 'keeps the manual workflow on target ids and action-owned summaries' {
+        $script:manualWorkflow | Should -Match '(?m)^\s*target_id:\s*$'
+        $script:manualWorkflow | Should -Match 'uses:\s+LabVIEW-Community-CI-CD/comparevi-history@v1\.1\.0'
+        $script:manualWorkflow | Should -Match 'Checkout trusted consumer contract'
+        $script:manualWorkflow | Should -Match 'path:\s+trusted-consumer'
+        $script:manualWorkflow | Should -Match 'Checkout PR head repository'
+        $script:manualWorkflow | Should -Match 'path:\s+pr-head'
+        $script:manualWorkflow | Should -Match 'repository_root:\s+pr-head'
+        $script:manualWorkflow | Should -Match 'target_spec_path:\s+\$\{\{ github\.workspace \}\}/trusted-consumer/\.github/comparevi-history-targets\.json'
+        $script:manualWorkflow | Should -Match 'target_id:\s+\$\{\{ inputs\.target_id \}\}'
+        $script:manualWorkflow | Should -Match 'source_branch_ref:\s+\$\{\{ steps\.pr\.outputs\[''head-ref''\] \}\}'
+        $script:manualWorkflow | Should -Match 'reviewer_surface:\s+manual'
+        $script:manualWorkflow | Should -Match 'invoke_script_path:\s+\$\{\{ github\.workspace \}\}/trusted-consumer/Tooling/Invoke-CompareVIHistoryHostedNILinux\.ps1'
+        $script:manualWorkflow | Should -Match 'public-step-summary-path'
+        $script:manualWorkflow | Should -Match 'Test-Path -LiteralPath \$env:PUBLIC_STEP_SUMMARY_PATH -PathType Leaf'
+        $script:manualWorkflow | Should -Not -Match '(?m)^\s*target_path:\s*$'
+        $script:manualWorkflow | Should -Not -Match 'default,attributes,front-panel,block-diagram'
+    }
+
+    It 'keeps the comment-gated workflow on target ids and action-owned comment bodies' {
+        $script:commentWorkflow | Should -Match 'FACADE_REF:\s+v1\.1\.0'
+        $script:commentWorkflow | Should -Match 'Usage:\s+/comparevi-history <target-id> \[--modes attributes,front-panel,block-diagram\]'
+        $script:commentWorkflow | Should -Match 'target-id=\$targetId'
+        $script:commentWorkflow | Should -Match 'Checkout trusted consumer contract'
+        $script:commentWorkflow | Should -Match 'path:\s+trusted-consumer'
+        $script:commentWorkflow | Should -Match 'Checkout PR head repository'
+        $script:commentWorkflow | Should -Match 'path:\s+pr-head'
+        $script:commentWorkflow | Should -Match 'repository_root:\s+pr-head'
+        $script:commentWorkflow | Should -Match 'target_spec_path:\s+\$\{\{ github\.workspace \}\}/trusted-consumer/\.github/comparevi-history-targets\.json'
+        $script:commentWorkflow | Should -Match 'target_id:\s+\$\{\{ steps\.request\.outputs\[''target-id''\] \}\}'
+        $script:commentWorkflow | Should -Match 'reviewer_surface:\s+comment-gated'
+        $script:commentWorkflow | Should -Match 'invoke_script_path:\s+\$\{\{ github\.workspace \}\}/trusted-consumer/Tooling/Invoke-CompareVIHistoryHostedNILinux\.ps1'
+        $script:commentWorkflow | Should -Match 'public-comment-path'
+        $script:commentWorkflow | Should -Match 'public-step-summary-path'
+        $script:commentWorkflow | Should -Match 'Test-Path -LiteralPath \$env:PUBLIC_STEP_SUMMARY_PATH -PathType Leaf'
+        $script:commentWorkflow | Should -Match 'Test-Path -LiteralPath \$env:COMMENT_PATH -PathType Leaf'
+        $script:commentWorkflow | Should -Not -Match 'target-path=\$targetPath'
+        $script:commentWorkflow | Should -Not -Match 'default,attributes,front-panel,block-diagram'
+    }
+
+    It 'documents the target catalog and action-owned public outputs' {
+        $script:docs | Should -Match '\.github/comparevi-history-targets\.json'
+        $script:docs | Should -Match 'vip-post-install-custom-action'
+        $script:docs | Should -Match 'public-comment-path'
+        $script:docs | Should -Match 'public-step-summary-path'
+        $script:docs | Should -Match 'public-run-path'
+        $script:docs | Should -Match 'LabVIEW-Community-CI-CD/comparevi-history@v1\.1\.0'
+        $script:docs | Should -Not -Match 'default,attributes,front-panel,block-diagram'
+    }
+}

--- a/docs/comparevi-history-diagnostics.md
+++ b/docs/comparevi-history-diagnostics.md
@@ -1,26 +1,36 @@
 # CompareVI History Diagnostics
 
-This repository can consume `comparevi-history` as a released diagnostics facade for pull-request review without
-running that facade directly from untrusted PR events.
+This repository consumes `comparevi-history` as the canonical released VI history platform surface for pull-request
+review without running that platform directly from untrusted PR events.
 
 ## Workflows
 
 - [`.github/workflows/comparevi-history-manual-pr-diagnostics.yml`](../.github/workflows/comparevi-history-manual-pr-diagnostics.yml)
-  is a maintainer-dispatched workflow for inspecting a specific pull request and repository-relative VI path on demand.
+  is a maintainer-dispatched workflow for inspecting a specific pull request and checked-in comparevi-history target id
+  on demand.
 - [`.github/workflows/comparevi-history-comment-gated.yml`](../.github/workflows/comparevi-history-comment-gated.yml)
   is a maintainer-only slash-command workflow that runs when a trusted maintainer comments
-  `/comparevi-history <repository-relative-vi-path> [--modes comma,list]` on a pull request.
+  `/comparevi-history <target-id> [--modes attributes,front-panel,block-diagram]` on a pull request.
+- [`.github/comparevi-history-targets.json`](../.github/comparevi-history-targets.json) is the repo-owned target
+  catalog that declares which VI history targets this consumer exposes.
 
 Both workflows:
 
 - use released `LabVIEW-Community-CI-CD/comparevi-history` refs only
+- pin the immutable release `LabVIEW-Community-CI-CD/comparevi-history@v1.1.0`
 - run on `ubuntu-latest`
 - pre-pull `nationalinstruments/labview:2026q1-linux` under a repo-level concurrency group so image acquisition and
   compare execution stay serialized
 - resolve the PR head repository and SHA dynamically
-- use the repo-local `Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1` adapter as a maintainer-controlled
+- check out the trusted base repository to supply `.github/comparevi-history-targets.json` and the hosted invoke adapter
+- check out the PR head into a separate path so only the inspected content comes from the untrusted branch or fork
+- route requests through the trusted target catalog checkout instead of the PR head checkout
+- use only explicit public compare modes: `attributes`, `front-panel`, and `block-diagram`
+- use the trusted repo-local `Tooling/Invoke-CompareVIHistoryHostedNILinux.ps1` adapter as a maintainer-controlled
   `invoke_script_path`
-- upload diagnostics artifacts plus reviewer-facing mode summaries
+- upload diagnostics artifacts
+- append the action-owned `public-step-summary-path`
+- publish the action-owned `public-comment-path` for comment-gated reviewer flows
 
 ## Release Contract
 
@@ -31,7 +41,10 @@ Both workflows:
 - Consumer workflows here should not set maintainer-only backend override inputs such as `comparevi_repository` or
   `comparevi_ref`.
 - The hosted invoke adapter resolves `Run-NILinuxContainerCompare.ps1` from `COMPAREVI_SCRIPTS_ROOT`, which is exported
-  by the released facade while it runs the released backend bundle.
+  by the released platform while it runs the released backend bundle.
+- Reviewer-facing consumers in this repository should rely on the action-owned outputs
+  `public-comment-path`, `public-step-summary-path`, `public-run-path`, and `history-summary-json` instead of
+  rebuilding markdown inline.
 
 ## Upstream and Fork Alignment
 
@@ -41,15 +54,21 @@ Both workflows:
 - The workflows are repo-local by design: they query the pull request from the current repository, then check out the
   PR head repo and SHA exactly as reported by the GitHub API.
 
+## Target Catalog
+
+- Current default target id: `vip-post-install-custom-action`
+- Current target path: `Tooling/deployment/VIP_Post-Install Custom Action.vi`
+- Public reviewer command: `/comparevi-history vip-post-install-custom-action --modes attributes,front-panel,block-diagram`
+- Branch-budget policy is bounded in the checked-in target catalog, not assembled ad hoc in workflows.
+
 ## Recommended Usage
 
 1. Start with the manual workflow when you want a low-risk maintainer-controlled diagnostics path.
-2. Use a stable VI path such as `Tooling/deployment/VIP_Post-Install Custom Action.vi` while validating hosted-runner
-   and trust behavior.
-3. Add the comment-gated workflow once maintainers are comfortable triggering diagnostics from PR comments on the
+2. Use target id `vip-post-install-custom-action` while validating hosted-runner and trust behavior.
+3. Use the comment-gated workflow once maintainers are comfortable triggering diagnostics from PR comments on the
    hosted runner under maintainer-only command gating.
-4. Keep the default mode bundle `default,attributes,front-panel,block-diagram` unless there is a documented reason to
-   narrow it.
+4. Keep the explicit public mode bundle `attributes,front-panel,block-diagram` unless there is a documented reason to
+   narrow it further.
 
 ## See Also
 


### PR DESCRIPTION
## Summary
- adopt the released comparevi-history target-catalog workflow shape in the demo consumer repo
- keep the target catalog and hosted invoke adapter on a trusted base-repo checkout while inspecting PR head content from a separate checkout
- replace inline reviewer rendering with action-owned public outputs and add a workflow contract regression test

## Validation
- `Invoke-Pester -Path @(''Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1'',''Tooling/tests/CiPipelineCompositeContract.Tests.ps1'') -CI`
- `comparevi-history` published-consumer validation run `23123869924` passed for both `v1` and `v1.1.0`
- direct Copilot CLI review found and I fixed:
  - untrusted target-catalog consumption from the PR head checkout
  - missing explicit file-existence guards for action-owned output paths

## Tracking
- closes `#4`
- downstream fork proof tracked in `svelderrainruiz/labview-icon-editor-demo#5`
- release dependency cleared by `LabVIEW-Community-CI-CD/comparevi-history@v1.1.0`
