### PR TITLE
#6 Add manual VI exploration workflow

### DIFF
--- a/.github/workflows/comparevi-history-manual-vi-exploration.yml
+++ b/.github/workflows/comparevi-history-manual-vi-exploration.yml
@@ -1,0 +1,44 @@
+name: CompareVI History Manual VI Exploration
+
+on:
+  workflow_dispatch:
+    inputs:
+      vi_path:
+        description: Repository-relative `.vi` path to explore
+        required: true
+        type: string
+      ref:
+        description: Repository ref to inspect
+        required: false
+        default: develop
+        type: string
+      compare_modes:
+        description: Reserved explicit compare mode bundle for later execution phases
+        required: false
+        default: attributes,front-panel,block-diagram
+        type: string
+      include_merge_parents:
+        description: Walk merge parents alongside the mainline when building the revision catalog
+        required: false
+        default: false
+        type: boolean
+      noise_policy:
+        description: Reserved noise policy for later execution phases
+        required: false
+        default: collapse
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  comparevi-history-manual-vi-exploration:
+    uses: LabVIEW-Community-CI-CD/comparevi-history/.github/workflows/manual-vi-exploration.yml@v1.2.0
+    with:
+      consumer_repository: ${{ github.repository }}
+      consumer_ref: ${{ inputs.ref }}
+      vi_path: ${{ inputs.vi_path }}
+      modes: ${{ inputs.compare_modes }}
+      include_merge_parents: ${{ inputs.include_merge_parents }}
+      noise_policy: ${{ inputs.noise_policy }}
+      platform_ref: v1.2.0

--- a/Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1
+++ b/Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1
@@ -7,17 +7,25 @@ Describe 'CompareVI History workflow contracts' {
     BeforeAll {
         $repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..')).Path
         $script:manualWorkflowPath = Join-Path $repoRoot '.github/workflows/comparevi-history-manual-pr-diagnostics.yml'
+        $script:manualExplorationWorkflowPath = Join-Path $repoRoot '.github/workflows/comparevi-history-manual-vi-exploration.yml'
         $script:commentWorkflowPath = Join-Path $repoRoot '.github/workflows/comparevi-history-comment-gated.yml'
         $script:targetCatalogPath = Join-Path $repoRoot '.github/comparevi-history-targets.json'
         $script:docsPath = Join-Path $repoRoot 'docs/comparevi-history-diagnostics.md'
 
-        foreach ($path in @($script:manualWorkflowPath, $script:commentWorkflowPath, $script:targetCatalogPath, $script:docsPath)) {
+        foreach ($path in @(
+            $script:manualWorkflowPath,
+            $script:manualExplorationWorkflowPath,
+            $script:commentWorkflowPath,
+            $script:targetCatalogPath,
+            $script:docsPath
+        )) {
             if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
                 throw "Required comparevi-history contract file not found: $path"
             }
         }
 
         $script:manualWorkflow = Get-Content -LiteralPath $script:manualWorkflowPath -Raw
+        $script:manualExplorationWorkflow = Get-Content -LiteralPath $script:manualExplorationWorkflowPath -Raw
         $script:commentWorkflow = Get-Content -LiteralPath $script:commentWorkflowPath -Raw
         $script:targetCatalog = Get-Content -LiteralPath $script:targetCatalogPath -Raw
         $script:docs = Get-Content -LiteralPath $script:docsPath -Raw
@@ -53,6 +61,29 @@ Describe 'CompareVI History workflow contracts' {
         $script:manualWorkflow | Should -Not -Match 'default,attributes,front-panel,block-diagram'
     }
 
+    It 'adds a thin manual exploration wrapper pinned to the published reusable workflow' {
+        $script:manualExplorationWorkflow | Should -Match '(?m)^\s*vi_path:\s*$'
+        $script:manualExplorationWorkflow | Should -Match '(?m)^\s*ref:\s*$'
+        $script:manualExplorationWorkflow | Should -Match 'default:\s+develop'
+        $script:manualExplorationWorkflow | Should -Match '(?m)^\s*compare_modes:\s*$'
+        $script:manualExplorationWorkflow | Should -Match 'default:\s+attributes,front-panel,block-diagram'
+        $script:manualExplorationWorkflow | Should -Match '(?m)^\s*include_merge_parents:\s*$'
+        $script:manualExplorationWorkflow | Should -Match 'type:\s+boolean'
+        $script:manualExplorationWorkflow | Should -Match '(?m)^\s*noise_policy:\s*$'
+        $script:manualExplorationWorkflow | Should -Match 'default:\s+collapse'
+        $script:manualExplorationWorkflow | Should -Match 'uses:\s+LabVIEW-Community-CI-CD/comparevi-history/\.github/workflows/manual-vi-exploration\.yml@v1\.2\.0'
+        $script:manualExplorationWorkflow | Should -Match 'consumer_repository:\s+\$\{\{ github\.repository \}\}'
+        $script:manualExplorationWorkflow | Should -Match 'consumer_ref:\s+\$\{\{ inputs\.ref \}\}'
+        $script:manualExplorationWorkflow | Should -Match 'vi_path:\s+\$\{\{ inputs\.vi_path \}\}'
+        $script:manualExplorationWorkflow | Should -Match 'modes:\s+\$\{\{ inputs\.compare_modes \}\}'
+        $script:manualExplorationWorkflow | Should -Match 'include_merge_parents:\s+\$\{\{ inputs\.include_merge_parents \}\}'
+        $script:manualExplorationWorkflow | Should -Match 'noise_policy:\s+\$\{\{ inputs\.noise_policy \}\}'
+        $script:manualExplorationWorkflow | Should -Match 'platform_ref:\s+v1\.2\.0'
+        $script:manualExplorationWorkflow | Should -Not -Match 'actions/checkout@'
+        $script:manualExplorationWorkflow | Should -Not -Match 'target_spec_path:'
+        $script:manualExplorationWorkflow | Should -Not -Match 'invoke_script_path:'
+    }
+
     It 'keeps the comment-gated workflow on target ids and action-owned comment bodies' {
         $script:commentWorkflow | Should -Match 'FACADE_REF:\s+v1\.1\.0'
         $script:commentWorkflow | Should -Match 'Usage:\s+/comparevi-history <target-id> \[--modes attributes,front-panel,block-diagram\]'
@@ -76,11 +107,15 @@ Describe 'CompareVI History workflow contracts' {
 
     It 'documents the target catalog and action-owned public outputs' {
         $script:docs | Should -Match '\.github/comparevi-history-targets\.json'
+        $script:docs | Should -Match '\.github/workflows/comparevi-history-manual-vi-exploration\.yml'
         $script:docs | Should -Match 'vip-post-install-custom-action'
+        $script:docs | Should -Match 'vi_path'
+        $script:docs | Should -Match 'revision-catalog\.json'
         $script:docs | Should -Match 'public-comment-path'
         $script:docs | Should -Match 'public-step-summary-path'
         $script:docs | Should -Match 'public-run-path'
         $script:docs | Should -Match 'LabVIEW-Community-CI-CD/comparevi-history@v1\.1\.0'
+        $script:docs | Should -Match 'LabVIEW-Community-CI-CD/comparevi-history/\.github/workflows/manual-vi-exploration\.yml@v1\.2\.0'
         $script:docs | Should -Not -Match 'default,attributes,front-panel,block-diagram'
     }
 }

--- a/docs/comparevi-history-diagnostics.md
+++ b/docs/comparevi-history-diagnostics.md
@@ -5,6 +5,11 @@ review without running that platform directly from untrusted PR events.
 
 ## Workflows
 
+- [`.github/workflows/comparevi-history-manual-vi-exploration.yml`](../.github/workflows/comparevi-history-manual-vi-exploration.yml)
+  is a maintainer-dispatched workflow for exploring one repo-relative `.vi` path on demand through the published
+  reusable `comparevi-history` manual exploration workflow. The wrapper stays thin: it forwards `vi_path`, `ref`,
+  `compare_modes`, `include_merge_parents`, and `noise_policy`, and pins both the reusable workflow ref and
+  `platform_ref` to `v1.2.0`.
 - [`.github/workflows/comparevi-history-manual-pr-diagnostics.yml`](../.github/workflows/comparevi-history-manual-pr-diagnostics.yml)
   is a maintainer-dispatched workflow for inspecting a specific pull request and checked-in comparevi-history target id
   on demand.
@@ -14,7 +19,16 @@ review without running that platform directly from untrusted PR events.
 - [`.github/comparevi-history-targets.json`](../.github/comparevi-history-targets.json) is the repo-owned target
   catalog that declares which VI history targets this consumer exposes.
 
-Both workflows:
+The manual exploration workflow:
+
+- pins the immutable reusable workflow
+  `LabVIEW-Community-CI-CD/comparevi-history/.github/workflows/manual-vi-exploration.yml@v1.2.0`
+- keeps `platform_ref` aligned with the workflow pin at `v1.2.0`
+- accepts repo-relative `vi_path` input plus `ref`, `compare_modes`, `include_merge_parents`, and `noise_policy`
+- uploads the Phase 1 `revision-catalog.json` artifact and appends the reusable workflow summary to the workflow run
+- does not add repo-local history discovery, chunk orchestration, or renderer logic
+
+The PR diagnostics workflows:
 
 - use released `LabVIEW-Community-CI-CD/comparevi-history` refs only
 - pin the immutable release `LabVIEW-Community-CI-CD/comparevi-history@v1.1.0`
@@ -31,6 +45,9 @@ Both workflows:
 - upload diagnostics artifacts
 - append the action-owned `public-step-summary-path`
 - publish the action-owned `public-comment-path` for comment-gated reviewer flows
+
+The manual exploration path is additive. Existing target-id PR diagnostics remain unchanged and continue to use the
+checked-in target catalog.
 
 ## Release Contract
 
@@ -69,6 +86,8 @@ Both workflows:
    hosted runner under maintainer-only command gating.
 4. Keep the explicit public mode bundle `attributes,front-panel,block-diagram` unless there is a documented reason to
    narrow it further.
+5. Use the manual VI exploration workflow when you want the full available revision catalog for a specific repo-relative
+   `.vi` path rather than the curated target-id diagnostics contract.
 
 ## See Also
 


### PR DESCRIPTION
## Summary
- add a thin manual `workflow_dispatch` wrapper for VI exploration
- pin the wrapper to the published `comparevi-history` reusable workflow at `v1.2.0`
- document and test the new manual exploration consumer contract without changing existing curated PR diagnostics flows

## Testing
- `Invoke-Pester -Path Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1 -CI`
