### PR TITLE
#22 Add comparevi-history corpus evidence pilot

### DIFF
--- a/.github/workflows/comparevi-history-corpus-evidence-pilot.yml
+++ b/.github/workflows/comparevi-history-corpus-evidence-pilot.yml
@@ -1,0 +1,254 @@
+name: CompareVI History Corpus Evidence Pilot
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Repository ref to inspect for the fixed seed targets
+        required: false
+        default: develop
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  comparevi-history-corpus-evidence-pilot:
+    runs-on: ubuntu-latest
+    env:
+      PLATFORM_REF: v1.3.8
+      COMPAREVI_NI_LINUX_IMAGE: nationalinstruments/labview:2026q1-linux
+      PILOT_RESULTS_ROOT: tests/results/ref-compare/history-exploration/corpus-pilot
+    steps:
+      - name: Checkout consumer repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          path: consumer
+
+      - name: Checkout comparevi-history platform repo
+        uses: actions/checkout@v5
+        with:
+          repository: LabVIEW-Community-CI-CD/comparevi-history
+          ref: ${{ env.PLATFORM_REF }}
+          fetch-depth: 1
+          path: platform
+
+      - name: Resolve checked-out consumer SHA
+        id: consumer_sha
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $consumerRoot = Join-Path $env:GITHUB_WORKSPACE 'consumer'
+          $sha = (& git -C $consumerRoot rev-parse HEAD).Trim()
+          "consumer_sha=$sha" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Pre-pull NI Linux image
+        shell: bash
+        run: docker pull "$COMPAREVI_NI_LINUX_IMAGE"
+
+      - name: Run corpus evidence pilot
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+
+          $consumerRoot = Join-Path $env:GITHUB_WORKSPACE 'consumer'
+          $platformRoot = Join-Path $env:GITHUB_WORKSPACE 'platform'
+          $pilotRoot = Join-Path $consumerRoot $env:PILOT_RESULTS_ROOT
+          $corpusRoot = Join-Path $pilotRoot 'corpus'
+          New-Item -ItemType Directory -Path $pilotRoot -Force | Out-Null
+          New-Item -ItemType Directory -Path $corpusRoot -Force | Out-Null
+
+          $seedTargets = @(
+            [ordered]@{
+              id = 'vip-post-install-custom-action'
+              path = 'Tooling/deployment/VIP_Post-Install Custom Action.vi'
+            },
+            [ordered]@{
+              id = 'vip-pre-install-custom-action'
+              path = 'Tooling/deployment/VIP_Pre-Install Custom Action.vi'
+            }
+          )
+
+          $sharedEvidencePaths = New-Object System.Collections.Generic.List[string]
+          $evidenceGraphPaths = New-Object System.Collections.Generic.List[string]
+          $targetReceipts = New-Object System.Collections.Generic.List[object]
+
+          foreach ($target in $seedTargets) {
+            $targetRoot = Join-Path $pilotRoot $target.id
+            New-Item -ItemType Directory -Path $targetRoot -Force | Out-Null
+
+            & "$platformRoot/scripts/Write-CompareVIHistoryRevisionCatalog.ps1" `
+              -RepositoryRoot $consumerRoot `
+              -TargetPath $target.path `
+              -SelectedRef '${{ steps.consumer_sha.outputs.consumer_sha }}' `
+              -ConsumerRepository $env:GITHUB_REPOSITORY `
+              -ConsumerRef '${{ inputs.ref }}' `
+              -ResultsDir $targetRoot `
+              -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
+
+            $catalogPath = Join-Path $targetRoot 'revision-catalog.json'
+            $chunkPlanPath = Join-Path $targetRoot 'chunk-plan.json'
+            $explorationRunPath = Join-Path $targetRoot 'exploration-run.json'
+            $evidenceGraphPath = Join-Path $targetRoot 'evidence-graph.json'
+            $sharedEvidencePath = Join-Path $targetRoot 'shared-evidence.json'
+            $indexMdPath = Join-Path $targetRoot 'index.md'
+            $indexHtmlPath = Join-Path $targetRoot 'index.html'
+            $timelineMdPath = Join-Path $targetRoot 'timeline.md'
+            $timelineHtmlPath = Join-Path $targetRoot 'timeline.html'
+            $bundlePath = Join-Path $targetRoot 'manual-vi-exploration-bundle.zip'
+
+            & "$platformRoot/scripts/Write-CompareVIHistoryChunkPlan.ps1" `
+              -RevisionCatalogPath $catalogPath `
+              -ResultsDir $targetRoot `
+              -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
+
+            & "$platformRoot/scripts/Invoke-CompareVIHistoryChunkExecution.ps1" `
+              -ConsumerRepositoryRoot $consumerRoot `
+              -ChunkPlanPath $chunkPlanPath `
+              -ResultsDir $targetRoot `
+              -Mode 'full' `
+              -NoisePolicy 'include' `
+              -GitHubToken $env:GITHUB_TOKEN `
+              -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
+
+            & "$platformRoot/scripts/Write-CompareVIHistoryExplorationRun.ps1" `
+              -RevisionCatalogPath $catalogPath `
+              -ChunkPlanPath $chunkPlanPath `
+              -ResultsDir $targetRoot `
+              -Modes 'full' `
+              -NoisePolicy 'include' `
+              -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
+
+            & "$platformRoot/scripts/Write-CompareVIHistoryExplorationBundle.ps1" `
+              -RevisionCatalogPath $catalogPath `
+              -ChunkPlanPath $chunkPlanPath `
+              -ResultsDir $targetRoot `
+              -ExplorationRunPath $explorationRunPath `
+              -IndexMd $indexMdPath `
+              -IndexHtml $indexHtmlPath `
+              -TimelineMd $timelineMdPath `
+              -TimelineHtml $timelineHtmlPath `
+              -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
+
+            & "$platformRoot/scripts/Write-CompareVIHistoryExplorationRun.ps1" `
+              -RevisionCatalogPath $catalogPath `
+              -ChunkPlanPath $chunkPlanPath `
+              -ResultsDir $targetRoot `
+              -Modes 'full' `
+              -NoisePolicy 'include' `
+              -IndexMd $indexMdPath `
+              -IndexHtml $indexHtmlPath `
+              -TimelineMd $timelineMdPath `
+              -TimelineHtml $timelineHtmlPath `
+              -BundlePath $bundlePath `
+              -BundleStatus 'succeeded' `
+              -BundleReason 'bundle-written' `
+              -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
+
+            foreach ($requiredPath in @(
+              $catalogPath,
+              $chunkPlanPath,
+              $explorationRunPath,
+              $evidenceGraphPath,
+              $sharedEvidencePath,
+              $indexMdPath,
+              $indexHtmlPath,
+              $timelineMdPath,
+              $timelineHtmlPath,
+              $bundlePath
+            )) {
+              if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+                throw "Expected corpus pilot artifact was not written: $requiredPath"
+              }
+            }
+
+            $sharedEvidencePaths.Add($sharedEvidencePath) | Out-Null
+            $evidenceGraphPaths.Add($evidenceGraphPath) | Out-Null
+            $targetReceipts.Add([ordered]@{
+              targetId = $target.id
+              targetPath = $target.path
+              resultsRoot = $targetRoot
+              revisionCatalogPath = $catalogPath
+              chunkPlanPath = $chunkPlanPath
+              explorationRunPath = $explorationRunPath
+              evidenceGraphPath = $evidenceGraphPath
+              sharedEvidencePath = $sharedEvidencePath
+              bundlePath = $bundlePath
+            }) | Out-Null
+          }
+
+          & "$platformRoot/scripts/Write-CompareVIHistoryCorpusIndex.ps1" `
+            -SharedEvidencePaths @($sharedEvidencePaths.ToArray()) `
+            -EvidenceGraphPaths @($evidenceGraphPaths.ToArray()) `
+            -OutputDir $corpusRoot `
+            -PageSize 2 `
+            -StepSummaryPath $env:GITHUB_STEP_SUMMARY | Out-Null
+
+          $corpusIndexPath = Join-Path $corpusRoot 'corpus-index.json'
+          $corpusPagesRoot = Join-Path $corpusRoot 'pages'
+          $downstreamManifestPath = Join-Path $corpusRoot 'downstream-processing-manifest.json'
+          foreach ($requiredPath in @($corpusIndexPath, $downstreamManifestPath)) {
+            if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+              throw "Expected corpus artifact was not written: $requiredPath"
+            }
+          }
+          if (-not (Test-Path -LiteralPath $corpusPagesRoot -PathType Container)) {
+            throw "Expected corpus pages directory was not written: $corpusPagesRoot"
+          }
+
+          $corpusIndex = Get-Content -LiteralPath $corpusIndexPath -Raw | ConvertFrom-Json -Depth 100
+          if ([string]$corpusIndex.schema -ne 'comparevi-history/corpus-index@v1') {
+            throw "Unexpected corpus index schema: $($corpusIndex.schema)"
+          }
+          if ([int]$corpusIndex.corpus.targetCount -ne 2) {
+            throw "Expected exactly two corpus targets. Actual: $($corpusIndex.corpus.targetCount)"
+          }
+          if ([int]$corpusIndex.paging.pageCount -ne 1) {
+            throw "Expected a single corpus page for the two-target pilot. Actual: $($corpusIndex.paging.pageCount)"
+          }
+          if ([string]$corpusIndex.paging.continuationMode -ne 'page-ordinal') {
+            throw "Unexpected continuation mode: $($corpusIndex.paging.continuationMode)"
+          }
+          if (-not [bool]$corpusIndex.corpus.complete) {
+            throw "Corpus pilot failed closed with corpus.complete=$($corpusIndex.corpus.complete) and reason '$($corpusIndex.corpus.reason)'."
+          }
+
+          $observedTargetPaths = @($corpusIndex.targets | ForEach-Object { [string]$_.targetPath })
+          foreach ($expectedTargetPath in @(
+            'Tooling/deployment/VIP_Post-Install Custom Action.vi',
+            'Tooling/deployment/VIP_Pre-Install Custom Action.vi'
+          )) {
+            if ($observedTargetPaths -notcontains $expectedTargetPath) {
+              throw "Corpus pilot omitted expected target path '$expectedTargetPath'."
+            }
+          }
+
+          $pilotManifest = [ordered]@{
+            schema = 'labview-icon-editor-demo/corpus-evidence-pilot@v1'
+            generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
+            platformRef = $env:PLATFORM_REF
+            consumerRepository = $env:GITHUB_REPOSITORY
+            consumerRef = '${{ inputs.ref }}'
+            consumerSha = '${{ steps.consumer_sha.outputs.consumer_sha }}'
+            seedTargets = @($targetReceipts)
+            corpus = [ordered]@{
+              corpusIndexPath = $corpusIndexPath
+              corpusPagesRoot = $corpusPagesRoot
+              downstreamProcessingManifestPath = $downstreamManifestPath
+            }
+          }
+          $pilotManifest | ConvertTo-Json -Depth 64 | Set-Content -LiteralPath (Join-Path $pilotRoot 'corpus-pilot-manifest.json') -Encoding utf8
+
+      - name: Upload corpus pilot artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: comparevi-history-corpus-evidence-pilot-${{ github.run_id }}
+          path: consumer/${{ env.PILOT_RESULTS_ROOT }}
+          if-no-files-found: error

--- a/Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1
+++ b/Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1
@@ -8,6 +8,7 @@ Describe 'CompareVI History workflow contracts' {
         $repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..\..')).Path
         $script:manualWorkflowPath = Join-Path $repoRoot '.github/workflows/comparevi-history-manual-pr-diagnostics.yml'
         $script:manualExplorationWorkflowPath = Join-Path $repoRoot '.github/workflows/comparevi-history-manual-vi-exploration.yml'
+        $script:corpusPilotWorkflowPath = Join-Path $repoRoot '.github/workflows/comparevi-history-corpus-evidence-pilot.yml'
         $script:commentWorkflowPath = Join-Path $repoRoot '.github/workflows/comparevi-history-comment-gated.yml'
         $script:targetCatalogPath = Join-Path $repoRoot '.github/comparevi-history-targets.json'
         $script:docsPath = Join-Path $repoRoot 'docs/comparevi-history-diagnostics.md'
@@ -15,6 +16,7 @@ Describe 'CompareVI History workflow contracts' {
         foreach ($path in @(
             $script:manualWorkflowPath,
             $script:manualExplorationWorkflowPath,
+            $script:corpusPilotWorkflowPath,
             $script:commentWorkflowPath,
             $script:targetCatalogPath,
             $script:docsPath
@@ -26,6 +28,7 @@ Describe 'CompareVI History workflow contracts' {
 
         $script:manualWorkflow = Get-Content -LiteralPath $script:manualWorkflowPath -Raw
         $script:manualExplorationWorkflow = Get-Content -LiteralPath $script:manualExplorationWorkflowPath -Raw
+        $script:corpusPilotWorkflow = Get-Content -LiteralPath $script:corpusPilotWorkflowPath -Raw
         $script:commentWorkflow = Get-Content -LiteralPath $script:commentWorkflowPath -Raw
         $script:targetCatalog = Get-Content -LiteralPath $script:targetCatalogPath -Raw
         $script:docs = Get-Content -LiteralPath $script:docsPath -Raw
@@ -84,6 +87,30 @@ Describe 'CompareVI History workflow contracts' {
         $script:manualExplorationWorkflow | Should -Not -Match 'invoke_script_path:'
     }
 
+    It 'adds a thin corpus pilot workflow pinned to released comparevi-history scripts' {
+        $script:corpusPilotWorkflow | Should -Match 'name:\s+CompareVI History Corpus Evidence Pilot'
+        $script:corpusPilotWorkflow | Should -Match '(?m)^\s*workflow_dispatch:\s*$'
+        $script:corpusPilotWorkflow | Should -Match '(?m)^\s*ref:\s*$'
+        $script:corpusPilotWorkflow | Should -Match 'default:\s+develop'
+        $script:corpusPilotWorkflow | Should -Match 'PLATFORM_REF:\s+v1\.3\.8'
+        $script:corpusPilotWorkflow | Should -Match 'PILOT_RESULTS_ROOT:\s+tests/results/ref-compare/history-exploration/corpus-pilot'
+        $script:corpusPilotWorkflow | Should -Match 'repository:\s+LabVIEW-Community-CI-CD/comparevi-history'
+        $script:corpusPilotWorkflow | Should -Match 'ref:\s+\$\{\{ env\.PLATFORM_REF \}\}'
+        $script:corpusPilotWorkflow | Should -Match 'Write-CompareVIHistoryRevisionCatalog\.ps1'
+        $script:corpusPilotWorkflow | Should -Match 'Invoke-CompareVIHistoryChunkExecution\.ps1'
+        $script:corpusPilotWorkflow | Should -Match 'Write-CompareVIHistoryExplorationRun\.ps1'
+        $script:corpusPilotWorkflow | Should -Match 'Write-CompareVIHistoryExplorationBundle\.ps1'
+        $script:corpusPilotWorkflow | Should -Match 'Write-CompareVIHistoryCorpusIndex\.ps1'
+        $script:corpusPilotWorkflow | Should -Match 'Tooling/deployment/VIP_Post-Install Custom Action\.vi'
+        $script:corpusPilotWorkflow | Should -Match 'Tooling/deployment/VIP_Pre-Install Custom Action\.vi'
+        $script:corpusPilotWorkflow | Should -Match 'corpus-index\.json'
+        $script:corpusPilotWorkflow | Should -Match 'downstream-processing-manifest\.json'
+        $script:corpusPilotWorkflow | Should -Match 'comparevi-history-corpus-evidence-pilot-\$\{\{ github\.run_id \}\}'
+        $script:corpusPilotWorkflow | Should -Not -Match 'comparevi_repository:'
+        $script:corpusPilotWorkflow | Should -Not -Match 'comparevi_ref:'
+        $script:corpusPilotWorkflow | Should -Not -Match 'target_spec_path:'
+    }
+
     It 'keeps the comment-gated workflow on target ids and action-owned comment bodies' {
         $script:commentWorkflow | Should -Match 'FACADE_REF:\s+v1\.1\.0'
         $script:commentWorkflow | Should -Match 'Usage:\s+/comparevi-history <target-id> \[--modes attributes,front-panel,block-diagram\]'
@@ -108,14 +135,20 @@ Describe 'CompareVI History workflow contracts' {
     It 'documents the target catalog and action-owned public outputs' {
         $script:docs | Should -Match '\.github/comparevi-history-targets\.json'
         $script:docs | Should -Match '\.github/workflows/comparevi-history-manual-vi-exploration\.yml'
+        $script:docs | Should -Match '\.github/workflows/comparevi-history-corpus-evidence-pilot\.yml'
         $script:docs | Should -Match 'vip-post-install-custom-action'
         $script:docs | Should -Match 'vi_path'
         $script:docs | Should -Match 'revision-catalog\.json'
+        $script:docs | Should -Match 'corpus-index\.json'
+        $script:docs | Should -Match 'downstream-processing-manifest\.json'
+        $script:docs | Should -Match 'VIP_Post-Install Custom Action\.vi'
+        $script:docs | Should -Match 'VIP_Pre-Install Custom Action\.vi'
         $script:docs | Should -Match 'public-comment-path'
         $script:docs | Should -Match 'public-step-summary-path'
         $script:docs | Should -Match 'public-run-path'
         $script:docs | Should -Match 'LabVIEW-Community-CI-CD/comparevi-history@v1\.1\.0'
         $script:docs | Should -Match 'LabVIEW-Community-CI-CD/comparevi-history/\.github/workflows/manual-vi-exploration\.yml@v1\.3\.7'
+        $script:docs | Should -Match 'LabVIEW-Community-CI-CD/comparevi-history@v1\.3\.8'
         $script:docs | Should -Match 'index\.md'
         $script:docs | Should -Match 'index\.html'
         $script:docs | Should -Match 'manual-vi-exploration-bundle\.zip'

--- a/docs/comparevi-history-diagnostics.md
+++ b/docs/comparevi-history-diagnostics.md
@@ -10,6 +10,12 @@ review without running that platform directly from untrusted PR events.
   reusable `comparevi-history` manual exploration workflow. The wrapper stays thin: it forwards `vi_path`, `ref`,
   `compare_modes`, `include_merge_parents`, and `noise_policy`, and pins both the reusable workflow ref and
   `platform_ref` to `v1.3.7`.
+- [`.github/workflows/comparevi-history-corpus-evidence-pilot.yml`](../.github/workflows/comparevi-history-corpus-evidence-pilot.yml)
+  is a maintainer-dispatched workflow that proves the corpus evidence contracts against the released
+  `comparevi-history` platform without adding repo-local corpus logic. It runs the released platform scripts for the
+  fixed seed targets:
+  - `Tooling/deployment/VIP_Post-Install Custom Action.vi`
+  - `Tooling/deployment/VIP_Pre-Install Custom Action.vi`
 - [`.github/workflows/comparevi-history-manual-pr-diagnostics.yml`](../.github/workflows/comparevi-history-manual-pr-diagnostics.yml)
   is a maintainer-dispatched workflow for inspecting a specific pull request and checked-in comparevi-history target id
   on demand.
@@ -32,6 +38,30 @@ The manual exploration workflow:
   and `manual-vi-exploration-bundle.zip`
 - appends the reusable workflow summary to the workflow run
 - does not add repo-local history discovery, chunk orchestration, or renderer logic
+
+The corpus evidence pilot workflow:
+
+- pins `LabVIEW-Community-CI-CD/comparevi-history@v1.3.8` by checking out the published platform repository at
+  `v1.3.8`
+- accepts only `ref` as operator input; the VI target set is fixed for this pilot
+- reuses the released platform scripts for:
+  - revision catalog discovery
+  - chunk planning
+  - chunk execution
+  - manual exploration aggregation
+  - bundle publication
+  - corpus aggregation
+- writes one deterministic corpus surface for both seed targets in one run:
+  - `corpus-index.json`
+  - `pages/corpus-page-*.json`
+  - `downstream-processing-manifest.json`
+  - `corpus-pilot-manifest.json`
+- uploads the full pilot results root under
+  `tests/results/ref-compare/history-exploration/corpus-pilot`
+- fails closed unless both seed targets complete and the corpus index reports deterministic `page-ordinal`
+  continuation
+- keeps the consumer wrapper thin by delegating the heavy lifting to the released platform instead of copying repo-local
+  corpus scripts
 
 The PR diagnostics workflows:
 


### PR DESCRIPTION
## Summary
- add a thin maintainer-dispatched corpus evidence pilot workflow pinned to released `comparevi-history` `v1.3.8`
- run the released manual exploration surface for the fixed seed targets in one workflow run
- aggregate the resulting shared evidence and evidence graphs into released corpus receipts for downstream processing

## Validation
- `Invoke-Pester -Path Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1 -CI`
- `git diff --check`

Closes #22
