### PR TITLE
#22 Fix corpus completeness contract check

### DIFF
--- a/.github/workflows/comparevi-history-corpus-evidence-pilot.yml
+++ b/.github/workflows/comparevi-history-corpus-evidence-pilot.yml
@@ -215,8 +215,8 @@ jobs:
           if ([string]$corpusIndex.paging.continuationMode -ne 'page-ordinal') {
             throw "Unexpected continuation mode: $($corpusIndex.paging.continuationMode)"
           }
-          if (-not [bool]$corpusIndex.corpus.complete) {
-            throw "Corpus pilot failed closed with corpus.complete=$($corpusIndex.corpus.complete) and reason '$($corpusIndex.corpus.reason)'."
+          if (-not [bool]$corpusIndex.completeness.isComplete) {
+            throw "Corpus pilot failed closed with completeness.isComplete=$($corpusIndex.completeness.isComplete) and reason '$($corpusIndex.completeness.reason)'."
           }
 
           $observedTargetPaths = @($corpusIndex.targets | ForEach-Object { [string]$_.targetPath })

--- a/Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1
+++ b/Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1
@@ -105,6 +105,7 @@ Describe 'CompareVI History workflow contracts' {
         $script:corpusPilotWorkflow | Should -Match 'Tooling/deployment/VIP_Pre-Install Custom Action\.vi'
         $script:corpusPilotWorkflow | Should -Match 'corpus-index\.json'
         $script:corpusPilotWorkflow | Should -Match 'downstream-processing-manifest\.json'
+        $script:corpusPilotWorkflow | Should -Match 'completeness\.isComplete'
         $script:corpusPilotWorkflow | Should -Match 'comparevi-history-corpus-evidence-pilot-\$\{\{ github\.run_id \}\}'
         $script:corpusPilotWorkflow | Should -Not -Match 'comparevi_repository:'
         $script:corpusPilotWorkflow | Should -Not -Match 'comparevi_ref:'


### PR DESCRIPTION
## Summary
- fix the corpus-pilot workflow to read completeness from the released corpus contract
- fail closed on `completeness.isComplete` instead of the nonexistent `corpus.complete`
- harden the consumer workflow contract test so this schema mismatch cannot regress

## Validation
- `Invoke-Pester -Path Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1 -CI`
- `git diff --check`

Fixes the post-merge failure from run `23205462733`.
Closes #22
