### PR TITLE
#22 Fix corpus target digest contract check

### DIFF
--- a/.github/workflows/comparevi-history-corpus-evidence-pilot.yml
+++ b/.github/workflows/comparevi-history-corpus-evidence-pilot.yml
@@ -219,7 +219,7 @@ jobs:
             throw "Corpus pilot failed closed with completeness.isComplete=$($corpusIndex.completeness.isComplete) and reason '$($corpusIndex.completeness.reason)'."
           }
 
-          $observedTargetPaths = @($corpusIndex.targets | ForEach-Object { [string]$_.targetPath })
+          $observedTargetPaths = @($corpusIndex.targetDigests | ForEach-Object { [string]$_.path })
           foreach ($expectedTargetPath in @(
             'Tooling/deployment/VIP_Post-Install Custom Action.vi',
             'Tooling/deployment/VIP_Pre-Install Custom Action.vi'

--- a/Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1
+++ b/Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1
@@ -106,6 +106,7 @@ Describe 'CompareVI History workflow contracts' {
         $script:corpusPilotWorkflow | Should -Match 'corpus-index\.json'
         $script:corpusPilotWorkflow | Should -Match 'downstream-processing-manifest\.json'
         $script:corpusPilotWorkflow | Should -Match 'completeness\.isComplete'
+        $script:corpusPilotWorkflow | Should -Match 'targetDigests'
         $script:corpusPilotWorkflow | Should -Match 'comparevi-history-corpus-evidence-pilot-\$\{\{ github\.run_id \}\}'
         $script:corpusPilotWorkflow | Should -Not -Match 'comparevi_repository:'
         $script:corpusPilotWorkflow | Should -Not -Match 'comparevi_ref:'


### PR DESCRIPTION
## Summary
- fix the corpus-pilot workflow to read expected target paths from `targetDigests`
- align the consumer wrapper with the released corpus index contract instead of assuming a nonexistent `targets` array
- extend the consumer contract test to lock that schema seam

## Validation
- `Invoke-Pester -Path Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1 -CI`
- `git diff --check`

Fixes the post-merge failure from run `23205819752`.
Closes #22
