### PR TITLE
#22 Fix corpus pilot manifest serialization

### DIFF
--- a/.github/workflows/comparevi-history-corpus-evidence-pilot.yml
+++ b/.github/workflows/comparevi-history-corpus-evidence-pilot.yml
@@ -229,15 +229,15 @@ jobs:
             }
           }
 
-          $pilotManifest = [ordered]@{
+          $pilotManifest = @{
             schema = 'labview-icon-editor-demo/corpus-evidence-pilot@v1'
             generatedAtUtc = (Get-Date).ToUniversalTime().ToString('o')
             platformRef = $env:PLATFORM_REF
             consumerRepository = $env:GITHUB_REPOSITORY
             consumerRef = '${{ inputs.ref }}'
             consumerSha = '${{ steps.consumer_sha.outputs.consumer_sha }}'
-            seedTargets = @($targetReceipts)
-            corpus = [ordered]@{
+            seedTargets = @($targetReceipts.ToArray())
+            corpus = @{
               corpusIndexPath = $corpusIndexPath
               corpusPagesRoot = $corpusPagesRoot
               downstreamProcessingManifestPath = $downstreamManifestPath


### PR DESCRIPTION
## Summary
- fix the convenience `corpus-pilot-manifest.json` writer so it serializes cleanly on Linux PowerShell
- keep the accepted corpus artifacts unchanged while removing a platform-neutral type mismatch
- preserve the thin consumer wrapper and released corpus contract

## Validation
- `Invoke-Pester -Path Tooling/tests/CompareVIHistoryWorkflowContracts.Tests.ps1 -CI`
- `git diff --check`

Fixes the post-merge failure from run `23206179499`.
Closes #22
